### PR TITLE
Add explicit width and height attributes to image elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -445,7 +445,7 @@ body{padding-bottom:52px}
       <div class="section-label">History</div>
       <div class="section-title">Roll of Honour</div>
     </div>
-    <img src="./images/teams-photo.png" alt="Teams lined up at a previous Golf Extravaganza" class="photo-banner" style="object-position:center top;max-height:260px">
+    <img src="./images/teams-photo.png" alt="Teams lined up at a previous Golf Extravaganza" class="photo-banner" width="1234" height="607" style="object-position:center top;max-height:260px">
 
     <div class="card mb24">
       <div style="display:flex;gap:12px;align-items:baseline;margin-bottom:16px">
@@ -515,7 +515,7 @@ body{padding-bottom:52px}
       <p style="font-size:.82rem;color:var(--grey);font-style:italic">⛳ Including a 36–7 Stableford blowout on Sunday. R. Hughes pulled driver on a 151m par 3 at Eagle Ridge, scattering players on the green.</p>
     </div>
 
-    <img src="./images/golf-course.png" alt="Golf course from a previous Golf Extravaganza" class="photo-banner" style="max-height:220px;object-position:center center">
+    <img src="./images/golf-course.png" alt="Golf course from a previous Golf Extravaganza" class="photo-banner" width="1213" height="873" style="max-height:220px;object-position:center center">
 
     <!-- Minor Awards History -->
     <div class="section-header" style="padding-top:32px">
@@ -769,7 +769,7 @@ body{padding-bottom:52px}
     </div>
 
     <!-- Accommodation -->
-    <img src="./images/accom-deck.png" alt="Property outdoor deck — 45 Anchorage Way 2, Yarrawonga" class="photo-banner" style="max-height:280px;object-position:center center">
+    <img src="./images/accom-deck.png" alt="Property outdoor deck — 45 Anchorage Way 2, Yarrawonga" class="photo-banner" width="858" height="615" style="max-height:280px;object-position:center center">
     <div class="accom-card">
       <h3>Accommodation</h3>
       <div class="accom-address">45 Anchorage Way 2, Yarrawonga VIC 3730</div>


### PR DESCRIPTION
## Summary
Added explicit `width` and `height` attributes to three image elements in the HTML to improve performance and prevent layout shift.

## Key Changes
- Added `width="1234" height="607"` to teams-photo.png image
- Added `width="1213" height="873"` to golf-course.png image
- Added `width="858" height="615"` to accom-deck.png image

## Implementation Details
These attributes specify the intrinsic dimensions of each image, allowing the browser to reserve the correct amount of space during layout calculation. This prevents Cumulative Layout Shift (CLS) and improves the Core Web Vitals score, particularly the visual stability of the page as images load.

https://claude.ai/code/session_014RwCWx4XahTnDZEE9mBRD2