### PR TITLE
Fix issues #25, #26, #27: edition copy, scroll masthead, music modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,13 +11,25 @@
 </head>
 <body>
 
+<!-- Music Warning Modal -->
+<div id="music-modal" class="music-modal hidden">
+  <div class="music-modal-card">
+    <div class="music-modal-icon">🔊</div>
+    <div class="music-modal-title">⚠ WARNING</div>
+    <div class="music-modal-body">This site contains <strong>appropriate music.</strong><br><br>Click YES to agree to play music.<br><br><strong>Turn your volume all the way up.</strong></div>
+    <button class="music-yes" onclick="startMusic()">YES, I AGREE</button><br>
+    <button class="music-no" onclick="dismissMusic()">no thanks (wrong answer)</button>
+  </div>
+</div>
+<audio id="bg-audio" src="TheSong.mp3" loop preload="none" style="display:none"></audio>
+
 <!-- ═══════════════════════════════════════════════════════════════════════
      MASTHEAD
 ═══════════════════════════════════════════════════════════════════════ -->
 <header class="masthead">
   <div class="masthead-inner">
     <div class="masthead-left">
-      <span>Fourth Edition</span>
+      <span>Inaugural Edition</span>
       <span class="moto">·</span>
       <span class="moto">2026</span>
     </div>
@@ -102,7 +114,7 @@
       <div class="meta">
         <span>01</span>
         <span class="num">Welcome</span>
-        <span>Fourth Edition</span>
+        <span>Inaugural Edition</span>
       </div>
       <div class="title-block">
         <h2 class="h-section">Same blokes. <em class="serif--italic">Same trophy.</em> New course.</h2>
@@ -113,7 +125,7 @@
     <div class="address-grid">
       <div class="body">
         <div class="first">
-          <p class="dropcap">What began as a cheeky mates trip — a few blokes, a golf bag, and the optimistic belief that a weekend away would somehow improve everyone's handicap — has graduated into a fully-fledged golfing tradition. The Wonga Cup is now in its fourth year, and the word "tradition" no longer feels like a stretch. It feels earned.</p>
+          <p class="dropcap">What began as a cheeky mates trip — a few blokes, a golf bag, and the optimistic belief that a weekend away would somehow improve everyone's handicap — has graduated into a fully-fledged golfing tradition. Four years in, the annual pilgrimage to Yarrawonga has earned its own name: The Wonga Cup. Inaugural edition. The word "tradition" no longer feels like a stretch. It feels earned.</p>
           <p>Twelve players. Three days. Three courses. One trophy. The format has evolved, the field has matured (in numbers if not always in conduct), and the stories have stacked up into something resembling a genuine tournament history. Yarrawonga's championship layout provides the perfect stage: the Murray Course, Black Bull, and Lake Course will test every part of the game — from tee shots to temperament.</p>
           <p>From Friday's match play battles to Saturday's scramble chaos and Sunday's individual Stableford grind, there are points up for grabs at every turn. The Wonga Cup is awarded to the winning team. Individual glory beckons in the form of Longest Drive, Nearest the Pin, and the not-entirely-coveted Silly Goose Hat. May the best team win — and may everyone else at least have a story worth telling at dinner.</p>
         </div>
@@ -784,7 +796,7 @@
       </div>
     </div>
     <div class="colophon">
-      <div>The Wonga Cup · Fourth Edition · 2026</div>
+      <div>The Wonga Cup · Inaugural Edition · 2026</div>
       <div>Set in Cormorant &amp; Geist</div>
     </div>
   </div>
@@ -808,6 +820,34 @@
 </div>
 
 <script src="theme.js"></script>
+<script>
+// Music consent modal
+function startMusic() {
+  document.getElementById('music-modal').classList.add('hidden');
+  sessionStorage.setItem('musicConsented', '1');
+  document.getElementById('bg-audio').play();
+}
+function dismissMusic() {
+  document.getElementById('music-modal').classList.add('hidden');
+  sessionStorage.setItem('musicConsented', 'dismissed');
+}
+if (!sessionStorage.getItem('musicConsented')) {
+  document.getElementById('music-modal').classList.remove('hidden');
+} else if (sessionStorage.getItem('musicConsented') === '1') {
+  document.getElementById('bg-audio').play();
+}
+
+// Masthead: transparent at top, solid once scrolled
+(function () {
+  const mast = document.querySelector('.masthead');
+  if (!mast) return;
+  function update() {
+    mast.classList.toggle('masthead--scrolled', window.scrollY > 80);
+  }
+  window.addEventListener('scroll', update, { passive: true });
+  update();
+})();
+</script>
 
 </body>
 </html>

--- a/scorecard.html
+++ b/scorecard.html
@@ -1379,6 +1379,17 @@ function updateCountdown() {
 }
 updateCountdown();
 setInterval(updateCountdown, 1000);
+
+// Masthead scroll behaviour (mirrors index.html)
+(function () {
+  const mast = document.querySelector('.masthead');
+  if (!mast) return;
+  function update() {
+    mast.classList.toggle('masthead--scrolled', window.scrollY > 80);
+  }
+  window.addEventListener('scroll', update, { passive: true });
+  update();
+})();
 </script>
 
 </body>

--- a/styles.css
+++ b/styles.css
@@ -215,11 +215,16 @@ hr.rule-ink { border-top-width: 1.5px; border-top-color: var(--ink); }
 
 /* ── masthead / nav ── */
 .masthead {
-  border-bottom: 1px solid var(--rule-strong);
-  background: var(--canvas);
+  border-bottom: 1px solid transparent;
+  background: transparent;
   position: sticky;
   top: 0;
   z-index: 50;
+  transition: background 0.3s ease, border-color 0.3s ease;
+}
+.masthead--scrolled {
+  background: var(--canvas);
+  border-bottom-color: var(--rule-strong);
 }
 .masthead-inner {
   display: grid;
@@ -1554,4 +1559,54 @@ html[data-mode="dark"] .hero-photo {
 .no-wrap { white-space: nowrap; }
 .acc { color: var(--accent); }
 .muted { color: var(--ink-mute); }
+
+/* ── music consent modal (shared) ── */
+.music-modal {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,.85);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 99999;
+  backdrop-filter: blur(6px);
+}
+.music-modal.hidden { display: none; }
+.music-modal-card {
+  background: var(--ink);
+  color: var(--canvas);
+  border: 1px solid var(--rule-strong);
+  border-radius: 4px;
+  padding: 40px 36px;
+  max-width: 400px;
+  width: calc(100% - 48px);
+  text-align: center;
+  box-shadow: 0 24px 64px rgba(0,0,0,.5);
+}
+.music-modal-icon { font-size: 2.5rem; margin-bottom: 14px; }
+.music-modal-title {
+  font-family: var(--display);
+  font-style: italic;
+  font-size: 1.6rem;
+  color: var(--canvas);
+  margin-bottom: 12px;
+}
+.music-modal-body { font-size: .9rem; line-height: 1.7; margin-bottom: 28px; color: var(--canvas); opacity: .85; }
+.music-modal-body strong { color: var(--canvas); opacity: 1; font-weight: 600; }
+.music-yes {
+  display: block; width: 100%;
+  padding: 14px 20px;
+  font-family: var(--mono); font-size: .75rem; letter-spacing: .12em; text-transform: uppercase;
+  background: var(--canvas); color: var(--ink);
+  border: none; border-radius: 2px;
+  cursor: pointer;
+  transition: opacity .2s;
+  margin-bottom: 10px;
+}
+.music-yes:hover { opacity: .85; }
+.music-no {
+  background: none; border: none;
+  color: var(--canvas); opacity: .4;
+  font-family: var(--mono); font-size: .7rem; letter-spacing: .08em; text-transform: uppercase;
+  cursor: pointer;
+  transition: opacity .2s;
+}
+.music-no:hover { opacity: .7; }
 .center { text-align: center; }


### PR DESCRIPTION
One commit missed in the previous merge. Closes #25, #26, #27.

## Changes

- **#25 Inaugural Edition** — "Fourth Edition" → "Inaugural Edition" in masthead, welcome section header, footer; body copy rewritten to clarify 4-year trip history vs first-year Wonga Cup name
- **#26 Scroll masthead** — Masthead starts transparent over the hero, fades to solid background once scrollY > 80px; applied to both pages
- **#27 Music modal on index.html** — Consent popup added to homepage, sharing `sessionStorage` key with scorecard so consent persists across both pages; CSS moved to `styles.css`

https://claude.ai/code/session_01LoZJA369wa4APMHux9nc1F

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoZJA369wa4APMHux9nc1F)_