### PR TITLE
Fix transparent masthead, hamburger menu, title update

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,25 +26,41 @@
 <!-- ═══════════════════════════════════════════════════════════════════════
      MASTHEAD
 ═══════════════════════════════════════════════════════════════════════ -->
-<header class="masthead">
+<header class="masthead" id="masthead">
   <div class="masthead-inner">
     <div class="masthead-left">
-      <span>Inaugural Edition</span>
+      <span>A.G.E.</span>
       <span class="moto">·</span>
       <span class="moto">2026</span>
     </div>
-    <a href="index.html" class="masthead-center">The Wonga Cup</a>
-    <nav class="masthead-right">
-      <a href="#welcome">Welcome</a>
-      <a href="#honour">Honours</a>
-      <a href="#field">Field</a>
-      <a href="#course">Course</a>
-      <a href="#programme">Schedule</a>
-      <a href="#kit">Kit List</a>
-      <a href="scorecard.html" class="nav-cta">Live Scorecard ↗</a>
-    </nav>
+    <a href="index.html" class="masthead-center">A.G.E IV: The Wonga Cup</a>
+    <div class="masthead-right">
+      <nav>
+        <a href="#welcome">Welcome</a>
+        <a href="#honour">Honours</a>
+        <a href="#field">Field</a>
+        <a href="#course">Course</a>
+        <a href="#programme">Schedule</a>
+        <a href="#kit">Kit List</a>
+        <a href="scorecard.html" class="nav-cta">Scorecard ↗</a>
+      </nav>
+      <button class="hamburger" id="hamburger" aria-label="Open menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
   </div>
 </header>
+
+<!-- Mobile nav -->
+<nav class="mobile-menu" id="mobile-menu" aria-hidden="true">
+  <a href="#welcome" class="mm-link" onclick="closeMenu()">Welcome</a>
+  <a href="#honour" class="mm-link" onclick="closeMenu()">Honours</a>
+  <a href="#field" class="mm-link" onclick="closeMenu()">Field</a>
+  <a href="#course" class="mm-link" onclick="closeMenu()">Course</a>
+  <a href="#programme" class="mm-link" onclick="closeMenu()">Schedule</a>
+  <a href="#kit" class="mm-link" onclick="closeMenu()">Kit List</a>
+  <a href="scorecard.html" class="mm-link mm-cta">Live Scorecard ↗</a>
+</nav>
 
 <!-- ═══════════════════════════════════════════════════════════════════════
      HERO
@@ -53,22 +69,10 @@
   <div class="hero-photo" style="background-image:url('images/course-black-bull.jpg')"></div>
   <div class="hero-scrim"></div>
   <div class="hero-inner">
-    <div class="hero-top">
-      <div class="lhs">
-        <span>The Wonga Cup</span>
-        <span>·</span>
-        <span>Est. 2023</span>
-      </div>
-      <div class="rhs">
-        <div>Yarrawonga · Murray Border</div>
-        <div>7 — 9 August 2026</div>
-      </div>
-    </div>
-
     <div class="hero-middle">
       <div class="hero-edition">IV</div>
       <div class="hero-title">The Wonga Cup</div>
-      <div class="hero-sub">Fourth annual. Yarrawonga, August 2026.</div>
+      <div class="hero-sub">Annual Golf Extravaganza · Fourth Edition · Yarrawonga 2026</div>
     </div>
 
     <div class="hero-bottom">
@@ -847,6 +851,28 @@ if (!sessionStorage.getItem('musicConsented')) {
   window.addEventListener('scroll', update, { passive: true });
   update();
 })();
+
+// Hamburger menu
+function toggleMenu() {
+  const menu = document.getElementById('mobile-menu');
+  const btn = document.getElementById('hamburger');
+  const open = menu.classList.toggle('is-open');
+  btn.classList.toggle('is-open', open);
+  btn.setAttribute('aria-expanded', open);
+  menu.setAttribute('aria-hidden', !open);
+  // Lock page scroll while menu is open
+  document.body.style.overflow = open ? 'hidden' : '';
+}
+function closeMenu() {
+  const menu = document.getElementById('mobile-menu');
+  const btn = document.getElementById('hamburger');
+  menu.classList.remove('is-open');
+  btn.classList.remove('is-open');
+  btn.setAttribute('aria-expanded', 'false');
+  menu.setAttribute('aria-hidden', 'true');
+  document.body.style.overflow = '';
+}
+document.getElementById('hamburger').addEventListener('click', toggleMenu);
 </script>
 
 </body>

--- a/styles.css
+++ b/styles.css
@@ -215,16 +215,19 @@ hr.rule-ink { border-top-width: 1.5px; border-top-color: var(--ink); }
 
 /* ── masthead / nav ── */
 .masthead {
-  border-bottom: 1px solid transparent;
-  background: transparent;
-  position: sticky;
-  top: 0;
+  position: fixed;
+  top: 0; left: 0; right: 0;
   z-index: 50;
-  transition: background 0.3s ease, border-color 0.3s ease;
+  background: transparent;
+  border-bottom: 1px solid transparent;
+  /* light text when transparent (over dark hero photo) */
+  color: rgba(241,234,215,0.85);
+  transition: background 0.35s ease, border-color 0.35s ease, color 0.35s ease;
 }
 .masthead--scrolled {
   background: var(--canvas);
   border-bottom-color: var(--rule-strong);
+  color: var(--ink-mute);
 }
 .masthead-inner {
   display: grid;
@@ -235,47 +238,125 @@ hr.rule-ink { border-top-width: 1.5px; border-top-color: var(--ink); }
   max-width: 1440px;
   margin: 0 auto;
 }
-.masthead-left, .masthead-right {
+.masthead-left {
   font-family: var(--mono);
   font-size: 11px;
   letter-spacing: 0.06em;
-  text-transform: none;
-  color: var(--ink-mute);
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  color: inherit;
+}
+.masthead-right {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
   display: flex;
   gap: 22px;
   align-items: center;
+  justify-content: flex-end;
+  color: inherit;
 }
-.masthead-right { justify-content: flex-end; }
 .masthead-center {
   font-family: var(--display);
   font-style: italic;
   font-weight: 500;
-  font-size: 1.5rem;
+  font-size: 1.35rem;
   letter-spacing: -0.005em;
   text-align: center;
   white-space: nowrap;
+  color: inherit;
 }
-.masthead nav a { transition: color .2s; }
-.masthead nav a:hover, .masthead nav a.active { color: var(--ink); }
+.masthead nav { display: flex; gap: 22px; align-items: center; }
+.masthead nav a { color: inherit; transition: opacity .2s; }
+.masthead nav a:hover, .masthead nav a.active { opacity: 0.65; }
 .masthead nav a.nav-cta {
-  color: var(--ink);
-  border: 1px solid var(--ink);
-  padding: 6px 12px;
+  border: 1px solid currentColor;
+  padding: 5px 12px;
   border-radius: 999px;
-  font-family: var(--mono);
   font-size: 10.5px;
   letter-spacing: 0.02em;
   transition: background .2s, color .2s;
+  opacity: 1;
 }
-.masthead nav a.nav-cta:hover {
+.masthead nav a.nav-cta:hover { opacity: 0.75; }
+.masthead--scrolled nav a.nav-cta:hover {
   background: var(--ink);
   color: var(--canvas);
+  opacity: 1;
 }
 
+/* ── hamburger ── */
+.hamburger {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 6px 4px;
+  color: inherit;
+  flex-shrink: 0;
+}
+.hamburger span {
+  display: block;
+  width: 22px;
+  height: 1.5px;
+  background: currentColor;
+  transition: transform .25s ease, opacity .25s ease;
+}
+.hamburger.is-open span:nth-child(1) { transform: translateY(6.5px) rotate(45deg); }
+.hamburger.is-open span:nth-child(2) { opacity: 0; }
+.hamburger.is-open span:nth-child(3) { transform: translateY(-6.5px) rotate(-45deg); }
+
+/* ── mobile menu ── */
+.mobile-menu {
+  position: fixed;
+  top: 52px; left: 0; right: 0;
+  z-index: 49;
+  background: var(--canvas);
+  border-bottom: 1px solid var(--rule-strong);
+  display: flex;
+  flex-direction: column;
+  padding: 8px 0 24px;
+  transform: translateY(-110%);
+  transition: transform .3s ease;
+  pointer-events: none;
+}
+.mobile-menu.is-open {
+  transform: translateY(0);
+  pointer-events: auto;
+}
+.mm-link {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  color: var(--ink-mute);
+  padding: 14px 24px;
+  border-bottom: 1px solid var(--rule);
+  transition: color .15s;
+}
+.mm-link:last-child { border-bottom: none; }
+.mm-link:hover { color: var(--ink); }
+.mm-cta {
+  color: var(--ink);
+  font-weight: 500;
+  border-bottom: none;
+  margin-top: 8px;
+}
+
+/* add scroll margin so fixed header doesn't cover section anchors */
+[id] { scroll-margin-top: 64px; }
+
 @media (max-width: 820px) {
-  .masthead-inner { grid-template-columns: auto 1fr; padding: 12px 20px; }
-  .masthead-right { display: none; }
+  .masthead-inner { grid-template-columns: auto 1fr auto; padding: 12px 20px; gap: 0; }
+  .masthead-right nav { display: none; }
   .masthead-left .moto { display: none; }
+  .hamburger { display: flex; }
+  .mobile-menu { top: 48px; }
+}
+@media (min-width: 821px) {
+  .mobile-menu { display: none; }
 }
 
 /* ── hero ── */
@@ -306,7 +387,7 @@ html[data-mode="dark"] .hero-photo {
   height: 100%;
   max-width: 1440px;
   margin: 0 auto;
-  padding: 32px 32px 56px;
+  padding: 80px 32px 56px; /* top offset for fixed masthead */
   display: flex;
   flex-direction: column;
   justify-content: space-between;


### PR DESCRIPTION
## Summary

- **Transparent masthead fixed** — switched from `position:sticky` to `position:fixed` so the hero photo renders behind the header (not below it). Light cream text in transparent state, dark ink text once scrolled solid. `scroll-margin-top:64px` on all `[id]` elements so anchor links aren't hidden under the fixed bar.
- **Hamburger menu** — animated 3-bar → ✕ button appears on mobile (≤820px). Opens a slide-down panel with links to all page sections plus Live Scorecard. Body scroll locks while open.
- **Title** — masthead center updated to *A.G.E IV: The Wonga Cup*, left side to *A.G.E. · 2026*
- **Hero simplified** — removed the redundant top info bar (dates/location duplicated the facts strip below). Hero subtitle now reads *Annual Golf Extravaganza · Fourth Edition · Yarrawonga 2026*.

https://claude.ai/code/session_01LoZJA369wa4APMHux9nc1F

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoZJA369wa4APMHux9nc1F)_