### PR TITLE
Align scorecard page brand with index.html

### DIFF
--- a/scorecard.css
+++ b/scorecard.css
@@ -5,7 +5,7 @@
 
 .sc-body { background: var(--canvas-2); }
 
-/* ── back link / masthead variant ── */
+/* ── back link — scorecard masthead is always solid so ink colours work ── */
 .back-link {
   font-family: var(--mono);
   font-size: 11px;
@@ -14,6 +14,41 @@
   transition: color .2s;
 }
 .back-link:hover { color: var(--ink); }
+
+/* ── editorial page header — light cream band bridging masthead → scoring ── */
+.sc-page-header {
+  background: var(--canvas);
+  border-bottom: 1px solid var(--rule-strong);
+  padding: 100px 32px 36px; /* top: masthead height + breathing room */
+  color: var(--ink);
+}
+.sc-page-header-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+.sc-page-eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-bottom: 10px;
+}
+.sc-page-title {
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 500;
+  font-size: clamp(2.8rem, 6vw, 4.8rem);
+  line-height: 1;
+  letter-spacing: -0.01em;
+  margin-bottom: 10px;
+}
+.sc-page-sub {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--ink-mute);
+}
 
 /* ──────────────────────────────────────────────────────────────────────
    TALLY HERO — the live scoreboard

--- a/scorecard.html
+++ b/scorecard.html
@@ -203,8 +203,8 @@ input[type=number].sf-in{width:76px;padding:5px 9px;font-size:1.05rem}
 .username-btn{width:100%;padding:12px 20px;font-family:var(--font-h);font-size:.9rem;font-weight:600;letter-spacing:2px;text-transform:uppercase;background:var(--gold);color:var(--navy);border:none;border-radius:var(--r);cursor:pointer;transition:var(--tr)}
 .username-btn:hover{background:var(--gold-light)}
 .username-btn:disabled{opacity:.5;cursor:not-allowed}
-.username-badge{position:fixed;top:16px;right:24px;font-family:var(--font-h);font-size:.75rem;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:var(--gold);background:rgba(240,180,41,.12);border:1px solid rgba(240,180,41,.3);padding:6px 14px;border-radius:100px;z-index:100}
-.offline-banner{position:fixed;top:60px;right:24px;background:rgba(200,0,0,.9);color:var(--white);padding:8px 16px;border-radius:var(--r);font-family:var(--font-h);font-size:.8rem;font-weight:600;letter-spacing:1px;text-transform:uppercase;z-index:999;animation:slideIn .3s ease}
+.username-badge{position:fixed;top:64px;right:24px;font-family:var(--font-h);font-size:.75rem;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:var(--gold);background:rgba(240,180,41,.12);border:1px solid rgba(240,180,41,.3);padding:6px 14px;border-radius:100px;z-index:100}
+.offline-banner{position:fixed;top:108px;right:24px;background:rgba(200,0,0,.9);color:var(--white);padding:8px 16px;border-radius:var(--r);font-family:var(--font-h);font-size:.8rem;font-weight:600;letter-spacing:1px;text-transform:uppercase;z-index:999;animation:slideIn .3s ease}
 @keyframes slideIn{from{transform:translateX(400px);opacity:0}to{transform:translateX(0);opacity:1}}
 
 /* ── MINI SCOREBOARD ── */
@@ -284,15 +284,24 @@ body{padding-bottom:52px}
 <!-- ══════════════════════════════════════
      NEW MASTHEAD
 ══════════════════════════════════════ -->
-<header class="masthead">
+<header class="masthead masthead--scrolled">
   <div class="masthead-inner">
     <div class="masthead-left">
-      <a href="index.html" class="back-link" style="font-family:var(--mono);font-size:11px;letter-spacing:.04em;color:var(--ink-mute)">← Tournament Info</a>
+      <a href="index.html" class="back-link">← Tournament Info</a>
     </div>
-    <a href="scorecard.html" class="masthead-center">The Wonga Cup · Scorecard</a>
+    <a href="scorecard.html" class="masthead-center">A.G.E IV: The Wonga Cup</a>
     <div class="masthead-right"></div>
   </div>
 </header>
+
+<!-- Editorial page header (light, matches index.html brand) -->
+<div class="sc-page-header">
+  <div class="sc-page-header-inner">
+    <div class="sc-page-eyebrow">Live Scoring · A.G.E IV · 2026</div>
+    <div class="sc-page-title">The Wonga Cup</div>
+    <div class="sc-page-sub">Yarrawonga &amp; Mulwala G.C. · 7–9 August</div>
+  </div>
+</div>
 
 <!-- Mini Scoreboard -->
 <div class="mini-sb" id="mini-sb">


### PR DESCRIPTION
## Summary

The scorecard page felt like a completely different site. This PR aligns its brand frame with index.html while keeping the dark scoring panels intact.

- **Masthead** — forced solid (`masthead--scrolled` on load) so there's no transparent-over-dark-navy flicker; title updated to *A.G.E IV: The Wonga Cup*; back-link now uses the proper CSS class instead of an inline style
- **Editorial page header** — a light cream `.sc-page-header` band sits between the masthead and the dark scoring content, displaying the Cormorant Garamond italic title and mono eyebrow in the same type system as index.html. Creates a visual bridge so both pages feel like the same site
- **Username badge + offline banner** — repositioned from `top:16px/60px` to `top:64px/108px` so they sit below the fixed masthead instead of overlapping it

https://claude.ai/code/session_01LoZJA369wa4APMHux9nc1F

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoZJA369wa4APMHux9nc1F)_