### PR TITLE
Restructure site from single page into 5 pages

### DIFF
--- a/golfers.html
+++ b/golfers.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="green" data-mode="light">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Golfers · The Wonga Cup · MMXXVI</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@300;400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<!-- Music Warning Modal -->
+<div id="music-modal" class="music-modal hidden">
+  <div class="music-modal-card">
+    <div class="music-modal-icon">🔊</div>
+    <div class="music-modal-title">⚠ WARNING</div>
+    <div class="music-modal-body">This site contains <strong>appropriate music.</strong><br><br>Click YES to agree to play music.<br><br><strong>Turn your volume all the way up.</strong></div>
+    <button class="music-yes" onclick="startMusic()">YES, I AGREE</button><br>
+    <button class="music-no" onclick="dismissMusic()">no thanks (wrong answer)</button>
+  </div>
+</div>
+<audio id="bg-audio" src="TheSong.mp3" loop preload="none" style="display:none"></audio>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     MASTHEAD
+═══════════════════════════════════════════════════════════════════════ -->
+<header class="masthead masthead--scrolled" id="masthead">
+  <div class="masthead-inner">
+    <div class="masthead-left">
+      <span>A.G.E.</span>
+      <span class="moto">·</span>
+      <span class="moto">2026</span>
+    </div>
+    <a href="index.html" class="masthead-center">A.G.E IV: The Wonga Cup</a>
+    <div class="masthead-right">
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="golfers.html">Golfers</a>
+        <a href="records.html">Records</a>
+        <a href="practical.html">Practical</a>
+        <a href="scorecard.html" class="nav-cta">Scorecard ↗</a>
+      </nav>
+      <button class="hamburger" id="hamburger" aria-label="Open menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </div>
+</header>
+
+<!-- Mobile nav -->
+<nav class="mobile-menu" id="mobile-menu" aria-hidden="true">
+  <a href="index.html" class="mm-link" onclick="closeMenu()">Home</a>
+  <a href="golfers.html" class="mm-link" onclick="closeMenu()">Golfers</a>
+  <a href="records.html" class="mm-link" onclick="closeMenu()">Records</a>
+  <a href="practical.html" class="mm-link" onclick="closeMenu()">Practical</a>
+  <a href="scorecard.html" class="mm-link mm-cta">Live Scorecard ↗</a>
+</nav>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     THE FIELD
+═══════════════════════════════════════════════════════════════════════ -->
+<section id="field" style="padding-top:96px">
+  <div class="shell shell--wide">
+    <div class="section-head">
+      <div class="meta">
+        <span>01</span>
+        <span class="num">Field</span>
+        <span>Twelve Starters</span>
+      </div>
+      <div class="title-block">
+        <h2 class="h-section">Twelve starters, <em class="serif--italic">drawn into two sides</em>.</h2>
+        <p class="standfirst">Ten regulars, one returning starter, one debutant. Listed in handicap order. Sides drawn Thursday night at the pub.</p>
+      </div>
+    </div>
+
+    <div class="field-grid">
+
+      <article class="player">
+        <div class="pnum">№ 01</div>
+        <div class="meta">
+          <div class="name">Brendan Cunningham<small>Fri–Sun</small></div>
+          <div class="hcp"><b>7.0</b>HCP</div>
+        </div>
+        <div class="badge-row"><span class="badge">2025 starter</span></div>
+        <p class="note">The bomber of the bunch. When Brendan connects, the ball travels far enough to need a customs clearance. Back for his second appearance and on a mission to erase the memories of last year's Stableford Sunday front nine — effectively 15 goals down at half time in AFL terms with his team in disarray. He's got the game and swagger for a "follow me lads" moment. The watch on Brendan: can he keep the driver under control.</p>
+      </article>
+
+      <article class="player">
+        <div class="pnum">№ 02</div>
+        <div class="meta">
+          <div class="name">Gary King<small>Fri–Sun</small></div>
+          <div class="hcp"><b>10.0</b>HCP</div>
+        </div>
+        <div class="badge-row"><span class="badge feat">Longest '25 · 272m</span><span class="badge">Goose '25</span></div>
+        <p class="note">The silent assassin. Gary doesn't say much, but when he does, it's usually to announce a birdie. Calm, composed, and capable of shooting numbers that turn heads — the kind of player you only notice when you realise he's already two up and about to go three clear. Here for the golf and here to win. Period. His off-course recovery involves a hired hyperbaric chamber and a travelling nutritionist, which explains why he's not staying with his team. Don't let him convince you otherwise. Won't double down for the Silly Goose Hat this year. Surely.</p>
+      </article>
+
+      <article class="player">
+        <div class="pnum">№ 03</div>
+        <div class="meta">
+          <div class="name">Matthew Smith<small>Fri–Sun</small></div>
+          <div class="hcp"><b>15.8</b>HCP</div>
+        </div>
+        <div class="badge-row"><span class="badge">Debutant '26</span></div>
+        <p class="note">First up start for Matthew Smith. A proud member of Melbourne Airport Golf Club — rumoured to do his best work somewhere between the terminal and the 18th green. Matt is expected to navigate the fairways with flair, composure and just enough quiet confidence to make the rest uneasy. Question is: will the influence of friends-gone-wild (Hughes et al.) affect his output, or will the long, well-manicured fairways of Yarrawonga be where he takes flight?</p>
+      </article>
+
+      <article class="player">
+        <div class="pnum">№ 04</div>
+        <div class="meta">
+          <div class="name">James McIntyre<small>Fri–Sun</small></div>
+          <div class="hcp"><b>17.7</b>HCP</div>
+        </div>
+        <div class="badge-row"><span class="badge">Portarlington '23</span></div>
+        <p class="note">The token lefty and master of the strategic iron off the tee. James plays the game his way — quietly, controlled, and often annoyingly effective. Uses a heart rate monitor to ensure peak performance. Still chasing his first weekend win; his 0-2 record is a constant talking point to anyone who'll listen. Expect crisp contact, controlled right-to-left fades, a strong putting game (potentially with a club that is not a putter), and a noticeable chip on his shoulder.</p>
+      </article>
+
+      <article class="player">
+        <div class="pnum">№ 05</div>
+        <div class="meta">
+          <div class="name">Cayden Woods<small>Sat–Sun Only</small></div>
+          <div class="hcp"><b>24.0</b>HCP</div>
+        </div>
+        <div class="badge-row"><span class="badge gold">Champion '24</span></div>
+        <p class="note">Cayden has an unmatched ability to find good lies where none exist. If you hear the sound of a bus barrelling down the fairway, don't panic — it's just Cayden's big square-faced driver. A self-proclaimed human fairway finder who doesn't miss fairways, period. If he misses one this year, someone probably distracted him mid-backswing.</p>
+      </article>
+
+      <article class="player">
+        <div class="pnum">№ 06</div>
+        <div class="meta">
+          <div class="name">Scott Rumbelow<small>Fri–Sun</small></div>
+          <div class="hcp"><b>25.0</b>HCP</div>
+        </div>
+        <div class="badge-row"><span class="badge">Meltdown '24</span></div>
+        <p class="note">The workhorse of the weekend. Scott's one of the most frequent golfers in the group and improving every season — a driving force behind the Annual Golf Extravaganza. Don't be fooled by the friendly smile; beneath it lies a man who is absolutely here to win. Loves the beers and will ensure any opposition player's glass is constantly topped up. Don't mistake the laid-back exterior under that bucket hat. There's a competitor in there.</p>
+      </article>
+
+      <article class="player">
+        <div class="pnum">№ 07</div>
+        <div class="meta">
+          <div class="name">Matthew Freestun<small>Fri–Sun</small></div>
+          <div class="hcp"><b>26.7</b>HCP</div>
+        </div>
+        <div class="badge-row"><span class="badge gold">Champion '24</span><span class="badge">Longest '24</span></div>
+        <p class="note">The perennial smokey. When he's on, he's on. Freestun has that rare ability to light up a course out of nowhere — his calm demeanour and light repetitive foot-tampering at address masks a dangerously competitive edge. First picked in almost any team at his handicap. When his swing clicks, fairways shrink, greens enlarge, and the field gets nervous. The temperament of a pro, the unpredictability of a weekend warrior.</p>
+      </article>
+
+      <article class="player">
+        <div class="pnum">№ 08</div>
+        <div class="meta">
+          <div class="name">Nathan Freestun<small>Fri–Sun</small></div>
+          <div class="hcp"><b>27.0</b>HCP</div>
+        </div>
+        <div class="badge-row"><span class="badge">Meltdown '25</span></div>
+        <p class="note">The tactician and one of the main men behind the annual golf events. His golf doesn't talk — so his strategy will. He'll either be plotting pairings to give his team the best chance of a win, or fine-tuning his wedge game to thin another one straight across the green. Nathan loves the golf weekend, with skill and ambition often being misunderstood by those who haven't seen him at full tilt.</p>
+      </article>
+
+      <article class="player">
+        <div class="pnum">№ 09</div>
+        <div class="meta">
+          <div class="name">Steve Koenig<small>Fri–Sun</small></div>
+          <div class="hcp"><b>31.0</b>HCP</div>
+        </div>
+        <div class="badge-row"><span class="badge gold">Champion '23 '25</span></div>
+        <p class="note">The Smiling Assassin. Don't be fooled by the grin — Steve hasn't lost yet and isn't planning to start now. Universally liked, with a knack for being underestimated right up until he's shaking your hand on 18. Spectators are advised to stand to the right of the fairway — his driver has been known to explore the scenic route hard left off the tee box.</p>
+      </article>
+
+      <article class="player">
+        <div class="pnum">№ 10</div>
+        <div class="meta">
+          <div class="name">Jimmy Hepburn<small>Fri–Sun</small></div>
+          <div class="hcp"><b>TBC</b>HCP</div>
+        </div>
+        <div class="badge-row"><span class="badge">Debutant '26</span></div>
+        <p class="note">The great unknown. Handicap still pending, reputation for early-morning beers already confirmed. Jimmy's a crowd favourite and most people haven't even met him yet. Paired with Robert Hughes, this duo promises chaos, comedy, and possibly greatness. Early scouting reports describe him as "dangerous." Whether that applies to his golf or his nightlife remains to be seen. Either way, eyes will be on Jimmy.</p>
+      </article>
+
+      <article class="player">
+        <div class="pnum">№ 11</div>
+        <div class="meta">
+          <div class="name">Robert Hughes<small>Fri–Sun</small></div>
+          <div class="hcp"><b>38.0</b>HCP</div>
+        </div>
+        <div class="badge-row"><span class="badge feat">Pub Capt. ×3</span></div>
+        <p class="note">Equal parts golfer, entertainer, and hydration specialist — maybe a little less golfer on second thought. Unbeaten across 3 weekends for the Pub Captain's Choice Award, and this year won't be any different. Famous for his hand wedge technique. Rob plays the game with a smile and a stubby, always up for a laugh and never short of an excuse. He's here to be the group's DJ (4 songs in the playlist), make memories, and win something he didn't know he was competing for.</p>
+      </article>
+
+      <article class="player">
+        <div class="pnum">№ 12</div>
+        <div class="meta">
+          <div class="name">Ben Lepore<small>Sat–Sun Only</small></div>
+          <div class="hcp"><b>44.0</b>HCP</div>
+        </div>
+        <div class="badge-row"><span class="badge gold">Champion '24</span></div>
+        <p class="note">A walking, talking commentary track. Few men can talk their way through a round quite like Ben. His sledging is as relentless as his enthusiasm, and while he's yet to prove golf is his main focus, he's unbeaten at talking opponents out of form (1-0 record). Known to hit his fifth off the tee and still walk away with par. Ben is golf's version of chaos — living proof that persistence and creative maths pays off — and we wouldn't have it any other way.</p>
+      </article>
+
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     FOOTER
+═══════════════════════════════════════════════════════════════════════ -->
+<footer class="foot">
+  <div class="shell">
+    <div class="row1">
+      <div class="col">
+        <h5>The Tournament</h5>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="golfers.html">Golfers</a></li>
+          <li><a href="records.html">History &amp; Records</a></li>
+          <li><a href="practical.html">Practical Info</a></li>
+          <li><a href="scorecard.html">Live Scorecard ↗</a></li>
+        </ul>
+      </div>
+      <div class="col">
+        <h5>Host Club</h5>
+        <ul>
+          <li>Yarrawonga &amp; Mulwala G.C.</li>
+          <li>Park &amp; Murray Streets</li>
+          <li>Mulwala NSW 2647</li>
+        </ul>
+      </div>
+      <div class="col">
+        <h5>Accommodation</h5>
+        <ul>
+          <li>45 Anchorage Way 2</li>
+          <li>Yarrawonga VIC 3730</li>
+          <li>Check-in from 2:00 PM, Friday</li>
+          <li>Checkout before 10:00 AM, Sunday</li>
+        </ul>
+      </div>
+    </div>
+    <div class="colophon">
+      <div>The Wonga Cup · Fourth Edition · 2026</div>
+      <div>Set in Cormorant &amp; Geist</div>
+    </div>
+  </div>
+</footer>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     THEME SWITCHER
+═══════════════════════════════════════════════════════════════════════ -->
+<div class="theme-switcher" id="theme-switcher" hidden>
+  <div class="tlabel">Coat of Paint</div>
+  <div class="row" role="radiogroup" aria-label="theme">
+    <button data-theme="green"  aria-label="green theme">Green</button>
+    <button data-theme="claret" aria-label="claret theme">Claret</button>
+    <button data-theme="navy"   aria-label="navy theme">Navy</button>
+  </div>
+  <div class="tlabel">Mode</div>
+  <div class="row" role="radiogroup" aria-label="light or dark">
+    <button data-mode="light">Light</button>
+    <button data-mode="dark">Dark</button>
+  </div>
+</div>
+
+<script src="theme.js"></script>
+<script>
+// Music consent modal
+function startMusic() {
+  document.getElementById('music-modal').classList.add('hidden');
+  sessionStorage.setItem('musicConsented', '1');
+  document.getElementById('bg-audio').play();
+}
+function dismissMusic() {
+  document.getElementById('music-modal').classList.add('hidden');
+  sessionStorage.setItem('musicConsented', 'dismissed');
+}
+if (!sessionStorage.getItem('musicConsented')) {
+  document.getElementById('music-modal').classList.remove('hidden');
+} else if (sessionStorage.getItem('musicConsented') === '1') {
+  document.getElementById('bg-audio').play();
+}
+
+// Hamburger menu
+function toggleMenu() {
+  const menu = document.getElementById('mobile-menu');
+  const btn = document.getElementById('hamburger');
+  const open = menu.classList.toggle('is-open');
+  btn.classList.toggle('is-open', open);
+  btn.setAttribute('aria-expanded', open);
+  menu.setAttribute('aria-hidden', !open);
+  document.body.style.overflow = open ? 'hidden' : '';
+}
+function closeMenu() {
+  const menu = document.getElementById('mobile-menu');
+  const btn = document.getElementById('hamburger');
+  menu.classList.remove('is-open');
+  btn.classList.remove('is-open');
+  btn.setAttribute('aria-expanded', 'false');
+  menu.setAttribute('aria-hidden', 'true');
+  document.body.style.overflow = '';
+}
+document.getElementById('hamburger').addEventListener('click', toggleMenu);
+</script>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -36,12 +36,10 @@
     <a href="index.html" class="masthead-center">A.G.E IV: The Wonga Cup</a>
     <div class="masthead-right">
       <nav>
-        <a href="#welcome">Welcome</a>
-        <a href="#honour">Honours</a>
-        <a href="#field">Field</a>
-        <a href="#course">Course</a>
-        <a href="#programme">Schedule</a>
-        <a href="#kit">Kit List</a>
+        <a href="index.html">Home</a>
+        <a href="golfers.html">Golfers</a>
+        <a href="records.html">Records</a>
+        <a href="practical.html">Practical</a>
         <a href="scorecard.html" class="nav-cta">Scorecard ↗</a>
       </nav>
       <button class="hamburger" id="hamburger" aria-label="Open menu" aria-expanded="false">
@@ -53,12 +51,10 @@
 
 <!-- Mobile nav -->
 <nav class="mobile-menu" id="mobile-menu" aria-hidden="true">
-  <a href="#welcome" class="mm-link" onclick="closeMenu()">Welcome</a>
-  <a href="#honour" class="mm-link" onclick="closeMenu()">Honours</a>
-  <a href="#field" class="mm-link" onclick="closeMenu()">Field</a>
-  <a href="#course" class="mm-link" onclick="closeMenu()">Course</a>
-  <a href="#programme" class="mm-link" onclick="closeMenu()">Schedule</a>
-  <a href="#kit" class="mm-link" onclick="closeMenu()">Kit List</a>
+  <a href="index.html" class="mm-link" onclick="closeMenu()">Home</a>
+  <a href="golfers.html" class="mm-link" onclick="closeMenu()">Golfers</a>
+  <a href="records.html" class="mm-link" onclick="closeMenu()">Records</a>
+  <a href="practical.html" class="mm-link" onclick="closeMenu()">Practical</a>
   <a href="scorecard.html" class="mm-link mm-cta">Live Scorecard ↗</a>
 </nav>
 
@@ -166,248 +162,13 @@
 </section>
 
 <!-- ═══════════════════════════════════════════════════════════════════════
-     ROLL OF HONOUR
-═══════════════════════════════════════════════════════════════════════ -->
-<section id="honour" class="alt">
-  <div class="shell">
-    <div class="section-head">
-      <div class="meta">
-        <span>02</span>
-        <span class="num">Honours</span>
-        <span>Past Champions</span>
-      </div>
-      <div class="title-block">
-        <h2 class="h-section">Three editions in, <em class="serif--italic">three different winners</em>.</h2>
-        <p class="standfirst">Started as an individual contest. Has been team-versus-team since 2024. Hasn't left Victoria yet.</p>
-      </div>
-    </div>
-
-    <div class="honour-grid">
-      <div>
-        <table class="ed-table">
-          <thead>
-            <tr><th style="width:80px">Year</th><th>Champion</th><th>Venue</th><th class="r">Margin</th></tr>
-          </thead>
-          <tbody>
-            <tr class="feat">
-              <td>2025</td>
-              <td>Team Underdogs<span class="smol">S. Rumbelow · S. Koenig · R. Hughes · N. Freestun</span></td>
-              <td>Mornington Peninsula<span class="smol">Moonah · Eagle Ridge · Devilbend</span></td>
-              <td class="r">60.5 — 38.5</td>
-            </tr>
-            <tr>
-              <td>2024</td>
-              <td>Six Foreskins<span class="smol">M. Freestun · S. Koenig · B. Lepore · C. Woods</span></td>
-              <td>Ballarat<span class="smol">Ballarat G.C. · RACV Goldfields · Buninyong</span></td>
-              <td class="r">31.5 — 21.5</td>
-            </tr>
-            <tr>
-              <td>2023</td>
-              <td>S. Koenig <em class="cap-italic muted" style="font-size:0.9em">(individual)</em><span class="smol">Inaugural — no teams contested</span></td>
-              <td>Bellarine Peninsula<span class="smol">Curlewis · Curlewis Mini · Portarlington</span></td>
-              <td class="r">+7</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <!-- Minor Awards History -->
-        <div style="margin-top:48px">
-          <h3 class="h-large" style="margin-bottom:24px">Minor Awards History</h3>
-          <table class="ed-table">
-            <thead>
-              <tr>
-                <th>Year</th>
-                <th>Longest Drive</th>
-                <th>Meltdown Medal</th>
-                <th>Pub Captain</th>
-                <th>Silly Goose Hat</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr><td>2023</td><td>N. Freestun 229m</td><td class="tag">N/A</td><td>R. Hughes</td><td class="tag">Not introduced</td></tr>
-              <tr><td>2024</td><td>M. Freestun 255m</td><td>S. Rumbelow</td><td>R. Hughes</td><td class="tag">Not introduced</td></tr>
-              <tr><td>2025</td><td>G. King 272m</td><td>N. Freestun</td><td>R. Hughes</td><td>G. King</td></tr>
-              <tr><td>2026</td><td class="tag">TBD</td><td class="tag">TBD</td><td class="tag">TBD</td><td class="tag">TBD</td></tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-      <div>
-        <div class="honour-photo" style="background-image:url('images/teams-photo.png');background-position:center 20%"></div>
-        <div class="cap">Defending Champions · Team Underdogs, Moonah Links 2025</div>
-
-        <!-- Records -->
-        <div style="margin-top:40px">
-          <h3 class="h-large" style="margin-bottom:16px">All-Time Records</h3>
-          <div class="records" style="grid-template-columns:1fr">
-            <div class="col">
-              <h4>Most Appearances</h4>
-              <div class="row"><div class="n">3</div><div class="who">J. McIntyre · M. Freestun · N. Freestun · R. Hughes · S. Rumbelow · S. Koenig</div></div>
-            </div>
-            <div class="col" style="margin-top:16px">
-              <h4>Most Team Wins</h4>
-              <div class="row"><div class="n">2</div><div class="who">S. Koenig</div></div>
-              <div class="row"><div class="n">1</div><div class="who">M. Freestun · N. Freestun · R. Hughes · S. Rumbelow · B. Lepore · C. Woods</div></div>
-              <div class="row"><div class="n muted">0</div><div class="who muted">J. McIntyre · B. Cunningham · G. King</div></div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════════════════════════
-     THE FIELD
-═══════════════════════════════════════════════════════════════════════ -->
-<section id="field">
-  <div class="shell shell--wide">
-    <div class="section-head">
-      <div class="meta">
-        <span>03</span>
-        <span class="num">Field</span>
-        <span>Twelve Starters</span>
-      </div>
-      <div class="title-block">
-        <h2 class="h-section">Twelve starters, <em class="serif--italic">drawn into two sides</em>.</h2>
-        <p class="standfirst">Ten regulars, one returning starter, one debutant. Listed in handicap order. Sides drawn Thursday night at the pub.</p>
-      </div>
-    </div>
-
-    <div class="field-grid">
-
-      <article class="player">
-        <div class="pnum">№ 01</div>
-        <div class="meta">
-          <div class="name">Brendan Cunningham<small>Fri–Sun</small></div>
-          <div class="hcp"><b>7.0</b>HCP</div>
-        </div>
-        <div class="badge-row"><span class="badge">2025 starter</span></div>
-        <p class="note">The bomber of the bunch. When Brendan connects, the ball travels far enough to need a customs clearance. Back for his second appearance and on a mission to erase the memories of last year's Stableford Sunday front nine — effectively 15 goals down at half time in AFL terms with his team in disarray. He's got the game and swagger for a "follow me lads" moment. The watch on Brendan: can he keep the driver under control.</p>
-      </article>
-
-      <article class="player">
-        <div class="pnum">№ 02</div>
-        <div class="meta">
-          <div class="name">Gary King<small>Fri–Sun</small></div>
-          <div class="hcp"><b>10.0</b>HCP</div>
-        </div>
-        <div class="badge-row"><span class="badge feat">Longest '25 · 272m</span><span class="badge">Goose '25</span></div>
-        <p class="note">The silent assassin. Gary doesn't say much, but when he does, it's usually to announce a birdie. Calm, composed, and capable of shooting numbers that turn heads — the kind of player you only notice when you realise he's already two up and about to go three clear. Here for the golf and here to win. Period. His off-course recovery involves a hired hyperbaric chamber and a travelling nutritionist, which explains why he's not staying with his team. Don't let him convince you otherwise. Won't double down for the Silly Goose Hat this year. Surely.</p>
-      </article>
-
-      <article class="player">
-        <div class="pnum">№ 03</div>
-        <div class="meta">
-          <div class="name">Matthew Smith<small>Fri–Sun</small></div>
-          <div class="hcp"><b>15.8</b>HCP</div>
-        </div>
-        <div class="badge-row"><span class="badge">Debutant '26</span></div>
-        <p class="note">First up start for Matthew Smith. A proud member of Melbourne Airport Golf Club — rumoured to do his best work somewhere between the terminal and the 18th green. Matt is expected to navigate the fairways with flair, composure and just enough quiet confidence to make the rest uneasy. Question is: will the influence of friends-gone-wild (Hughes et al.) affect his output, or will the long, well-manicured fairways of Yarrawonga be where he takes flight?</p>
-      </article>
-
-      <article class="player">
-        <div class="pnum">№ 04</div>
-        <div class="meta">
-          <div class="name">James McIntyre<small>Fri–Sun</small></div>
-          <div class="hcp"><b>17.7</b>HCP</div>
-        </div>
-        <div class="badge-row"><span class="badge">Portarlington '23</span></div>
-        <p class="note">The token lefty and master of the strategic iron off the tee. James plays the game his way — quietly, controlled, and often annoyingly effective. Uses a heart rate monitor to ensure peak performance. Still chasing his first weekend win; his 0-2 record is a constant talking point to anyone who'll listen. Expect crisp contact, controlled right-to-left fades, a strong putting game (potentially with a club that is not a putter), and a noticeable chip on his shoulder.</p>
-      </article>
-
-      <article class="player">
-        <div class="pnum">№ 05</div>
-        <div class="meta">
-          <div class="name">Cayden Woods<small>Sat–Sun Only</small></div>
-          <div class="hcp"><b>24.0</b>HCP</div>
-        </div>
-        <div class="badge-row"><span class="badge gold">Champion '24</span></div>
-        <p class="note">Cayden has an unmatched ability to find good lies where none exist. If you hear the sound of a bus barrelling down the fairway, don't panic — it's just Cayden's big square-faced driver. A self-proclaimed human fairway finder who doesn't miss fairways, period. If he misses one this year, someone probably distracted him mid-backswing.</p>
-      </article>
-
-      <article class="player">
-        <div class="pnum">№ 06</div>
-        <div class="meta">
-          <div class="name">Scott Rumbelow<small>Fri–Sun</small></div>
-          <div class="hcp"><b>25.0</b>HCP</div>
-        </div>
-        <div class="badge-row"><span class="badge">Meltdown '24</span></div>
-        <p class="note">The workhorse of the weekend. Scott's one of the most frequent golfers in the group and improving every season — a driving force behind the Annual Golf Extravaganza. Don't be fooled by the friendly smile; beneath it lies a man who is absolutely here to win. Loves the beers and will ensure any opposition player's glass is constantly topped up. Don't mistake the laid-back exterior under that bucket hat. There's a competitor in there.</p>
-      </article>
-
-      <article class="player">
-        <div class="pnum">№ 07</div>
-        <div class="meta">
-          <div class="name">Matthew Freestun<small>Fri–Sun</small></div>
-          <div class="hcp"><b>26.7</b>HCP</div>
-        </div>
-        <div class="badge-row"><span class="badge gold">Champion '24</span><span class="badge">Longest '24</span></div>
-        <p class="note">The perennial smokey. When he's on, he's on. Freestun has that rare ability to light up a course out of nowhere — his calm demeanour and light repetitive foot-tampering at address masks a dangerously competitive edge. First picked in almost any team at his handicap. When his swing clicks, fairways shrink, greens enlarge, and the field gets nervous. The temperament of a pro, the unpredictability of a weekend warrior.</p>
-      </article>
-
-      <article class="player">
-        <div class="pnum">№ 08</div>
-        <div class="meta">
-          <div class="name">Nathan Freestun<small>Fri–Sun</small></div>
-          <div class="hcp"><b>27.0</b>HCP</div>
-        </div>
-        <div class="badge-row"><span class="badge">Meltdown '25</span></div>
-        <p class="note">The tactician and one of the main men behind the annual golf events. His golf doesn't talk — so his strategy will. He'll either be plotting pairings to give his team the best chance of a win, or fine-tuning his wedge game to thin another one straight across the green. Nathan loves the golf weekend, with skill and ambition often being misunderstood by those who haven't seen him at full tilt.</p>
-      </article>
-
-      <article class="player">
-        <div class="pnum">№ 09</div>
-        <div class="meta">
-          <div class="name">Steve Koenig<small>Fri–Sun</small></div>
-          <div class="hcp"><b>31.0</b>HCP</div>
-        </div>
-        <div class="badge-row"><span class="badge gold">Champion '23 '25</span></div>
-        <p class="note">The Smiling Assassin. Don't be fooled by the grin — Steve hasn't lost yet and isn't planning to start now. Universally liked, with a knack for being underestimated right up until he's shaking your hand on 18. Spectators are advised to stand to the right of the fairway — his driver has been known to explore the scenic route hard left off the tee box.</p>
-      </article>
-
-      <article class="player">
-        <div class="pnum">№ 10</div>
-        <div class="meta">
-          <div class="name">Jimmy Hepburn<small>Fri–Sun</small></div>
-          <div class="hcp"><b>TBC</b>HCP</div>
-        </div>
-        <div class="badge-row"><span class="badge">Debutant '26</span></div>
-        <p class="note">The great unknown. Handicap still pending, reputation for early-morning beers already confirmed. Jimmy's a crowd favourite and most people haven't even met him yet. Paired with Robert Hughes, this duo promises chaos, comedy, and possibly greatness. Early scouting reports describe him as "dangerous." Whether that applies to his golf or his nightlife remains to be seen. Either way, eyes will be on Jimmy.</p>
-      </article>
-
-      <article class="player">
-        <div class="pnum">№ 11</div>
-        <div class="meta">
-          <div class="name">Robert Hughes<small>Fri–Sun</small></div>
-          <div class="hcp"><b>38.0</b>HCP</div>
-        </div>
-        <div class="badge-row"><span class="badge feat">Pub Capt. ×3</span></div>
-        <p class="note">Equal parts golfer, entertainer, and hydration specialist — maybe a little less golfer on second thought. Unbeaten across 3 weekends for the Pub Captain's Choice Award, and this year won't be any different. Famous for his hand wedge technique. Rob plays the game with a smile and a stubby, always up for a laugh and never short of an excuse. He's here to be the group's DJ (4 songs in the playlist), make memories, and win something he didn't know he was competing for.</p>
-      </article>
-
-      <article class="player">
-        <div class="pnum">№ 12</div>
-        <div class="meta">
-          <div class="name">Ben Lepore<small>Sat–Sun Only</small></div>
-          <div class="hcp"><b>44.0</b>HCP</div>
-        </div>
-        <div class="badge-row"><span class="badge gold">Champion '24</span></div>
-        <p class="note">A walking, talking commentary track. Few men can talk their way through a round quite like Ben. His sledging is as relentless as his enthusiasm, and while he's yet to prove golf is his main focus, he's unbeaten at talking opponents out of form (1-0 record). Known to hit his fifth off the tee and still walk away with par. Ben is golf's version of chaos — living proof that persistence and creative maths pays off — and we wouldn't have it any other way.</p>
-      </article>
-
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════════════════════════
      THE COURSE
 ═══════════════════════════════════════════════════════════════════════ -->
 <section id="course" class="alt">
   <div class="shell">
     <div class="section-head">
       <div class="meta">
-        <span>04</span>
+        <span>02</span>
         <span class="num">Course</span>
         <span>Three Layouts</span>
       </div>
@@ -493,7 +254,7 @@
   <div class="shell">
     <div class="section-head">
       <div class="meta">
-        <span>05</span>
+        <span>03</span>
         <span class="num">Schedule</span>
         <span>Three Days</span>
       </div>
@@ -561,209 +322,6 @@
 </section>
 
 <!-- ═══════════════════════════════════════════════════════════════════════
-     HONOURS — TROPHIES ON OFFER
-═══════════════════════════════════════════════════════════════════════ -->
-<section id="honours" class="alt">
-  <div class="shell shell--wide">
-    <div class="section-head">
-      <div class="meta">
-        <span>06</span>
-        <span class="num">Trophies</span>
-        <span>On the Line</span>
-      </div>
-      <div class="title-block">
-        <h2 class="h-section">One Cup. <em class="serif--italic">Six side honours.</em></h2>
-        <p class="standfirst">The Wonga Cup is contested between sides. The six minor honours are decided across individuals, hole records, and the verdict of a Pub Captain whose tenure is yet to be challenged.</p>
-      </div>
-    </div>
-
-    <div class="awards">
-      <div class="award">
-        <span class="l">Cup</span>
-        <span class="name">The <em>Wonga</em> Cup</span>
-        <p>Awarded to the winning side across all three days. Bragging rights until the following August.</p>
-        <span class="holder">Holders · Team Underdogs '25</span>
-      </div>
-      <div class="award">
-        <span class="l">Minor</span>
-        <span class="name">Longest <em>Drive</em></span>
-        <p>Furthest measured drive on the nominated hole. Carts ineligible.</p>
-        <span class="holder">Holder · G. King · 272m</span>
-      </div>
-      <div class="award">
-        <span class="l">Minor</span>
-        <span class="name">Nearest the <em>Pin</em></span>
-        <p>Closest tee shot to the flag on the nominated par 3.</p>
-        <span class="holder">Holder · vacant</span>
-      </div>
-      <div class="award">
-        <span class="l">Minor</span>
-        <span class="name">The <em>Silly Goose</em> Hat</span>
-        <p>For the single most baffling decision made on a golf course across the weekend.</p>
-        <span class="holder">Holder · G. King</span>
-      </div>
-      <div class="award">
-        <span class="l">Minor</span>
-        <span class="name">Worst <em>Blow-Up</em></span>
-        <p>Highest single-hole score in the tournament. A badge of honour for the genuinely cursed.</p>
-        <span class="holder">Holder · S. Rumbelow · −13</span>
-      </div>
-      <div class="award">
-        <span class="l">Minor</span>
-        <span class="name">The <em>Meltdown</em> Medal</span>
-        <p>For the most spectacular loss of composure observed on the course.</p>
-        <span class="holder">Holder · N. Freestun</span>
-      </div>
-      <div class="award">
-        <span class="l">Minor</span>
-        <span class="name">Pub Captain's <em>Choice</em></span>
-        <p>The wildcard. Awarded by the Pub Captain on merit or entertainment, whichever applies.</p>
-        <span class="holder">Holder · R. Hughes ×3</span>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════════════════════════
-     RECORDS / HALL OF FAME
-═══════════════════════════════════════════════════════════════════════ -->
-<section id="records" class="dense">
-  <div class="shell">
-    <div class="section-head">
-      <div class="meta">
-        <span>07</span>
-        <span class="num">Records</span>
-        <span>All-Time</span>
-      </div>
-      <div class="title-block">
-        <h2 class="h-section">Three editions in. <em class="serif--italic">The book starts to write itself.</em></h2>
-      </div>
-    </div>
-
-    <div class="records">
-      <div class="col">
-        <h4>Most Appearances</h4>
-        <div class="row"><div class="n">III</div><div class="who">J. McIntyre · M. Freestun · N. Freestun · R. Hughes · S. Rumbelow · S. Koenig</div></div>
-        <div class="row"><div class="n">II</div><div class="who">G. King · B. Cunningham</div></div>
-        <div class="row"><div class="n">I</div><div class="who">B. Lepore · C. Woods</div></div>
-      </div>
-
-      <div class="col">
-        <h4>Most Team Victories</h4>
-        <div class="row"><div class="n">II</div><div class="who">S. Koenig</div></div>
-        <div class="row"><div class="n">I</div><div class="who">M. Freestun · N. Freestun · R. Hughes · S. Rumbelow · B. Lepore · C. Woods</div></div>
-        <div class="row"><div class="n muted">0</div><div class="who muted">J. McIntyre · B. Cunningham · G. King</div></div>
-      </div>
-
-      <div class="col">
-        <h4>Career Numbers</h4>
-        <div class="row"><div class="n">272m</div><div class="who">Longest measured drive · G. King · 2025</div></div>
-        <div class="row"><div class="n">−7</div><div class="who">Inaugural weekend medal · S. Koenig · 2023</div></div>
-        <div class="row"><div class="n">36–7</div><div class="who">Largest Stableford margin on a single round · 2025</div></div>
-        <div class="row"><div class="n">×3</div><div class="who">R. Hughes — Pub Captain's Choice, every edition</div></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════════════════════════
-     KIT LIST
-═══════════════════════════════════════════════════════════════════════ -->
-<section id="kit" class="alt">
-  <div class="shell">
-    <div class="section-head">
-      <div class="meta">
-        <span>08</span>
-        <span class="num">Kit List</span>
-        <span>What to Bring</span>
-      </div>
-      <div class="title-block">
-        <h2 class="h-section">Pack like an adult. <em class="serif--italic">Play like a child.</em></h2>
-        <p class="standfirst">August in Yarrawonga: frost at sunrise, low twenties by lunch, a chance of a westerly off the lake. Pack for all three.</p>
-      </div>
-    </div>
-
-    <div class="kit-grid">
-      <div class="kit-col">
-        <h4>The Obvious</h4>
-        <ul class="kit-list">
-          <li><b>Clubs.</b> <span class="aside">A full set. Borrowing a wedge mid-round counts as a meltdown moment.</span></li>
-          <li><b>Balls.</b> <span class="aside">A dozen minimum. Two dozen if you play the lake holes the way you usually do.</span></li>
-          <li><b>Tees.</b> <span class="aside">Bring twice what you think you need.</span></li>
-          <li><b>Glove.</b> <span class="aside">Two, if there's any rain in the forecast.</span></li>
-          <li><b>Shoes.</b> <span class="aside">Spikeless or soft spikes. Pro shop is fussy.</span></li>
-        </ul>
-      </div>
-
-      <div class="kit-col">
-        <h4>On Course</h4>
-        <ul class="kit-list">
-          <li><b>Collared shirts × 3.</b> <span class="aside">Clubhouse rules. No singlets, no exceptions.</span></li>
-          <li><b>Rain jacket.</b> <span class="aside">It's August. Don't be the bloke borrowing one.</span></li>
-          <li><b>Layers.</b> <span class="aside">A puffer or vest for the early tee.</span></li>
-          <li><b>Hat.</b> <span class="aside">Cap or bucket. The Goose Hat is issued separately.</span></li>
-          <li><b>Sunscreen.</b> <span class="aside">Yes, even in August. UV doesn't read calendars.</span></li>
-          <li><b>Towel.</b> <span class="aside">For clubs. Not for crying.</span></li>
-        </ul>
-      </div>
-
-      <div class="kit-col">
-        <h4>Accommodation</h4>
-        <ul class="kit-list">
-          <li><b>Sheets &amp; pillowcases.</b> <span class="aside">Not provided — pack accordingly or air-dry.</span></li>
-          <li><b>Towels.</b> <span class="aside">Bath towels not provided.</span></li>
-          <li><b>Food &amp; drinks.</b> <span class="aside">For the house — kitchen &amp; BBQ are available.</span></li>
-          <li><b>Toiletries.</b> <span class="aside">All the usual suspects.</span></li>
-          <li><b>Warm layers.</b> <span class="aside">Yarrawonga evenings get cold in August.</span></li>
-        </ul>
-
-        <h4 style="margin-top:32px">Wallet</h4>
-        <ul class="kit-list">
-          <li><b>$200 cash.</b> <span class="aside">$100 for skins &amp; side bets. $100 for the pub.</span></li>
-          <li><b>Card.</b> <span class="aside">Accommodation, dinners, green fees, that round you owe Hughesy.</span></li>
-          <li><b>Medicare card.</b> <span class="aside">Optimistic. Possible.</span></li>
-        </ul>
-      </div>
-    </div>
-
-    <!-- Logistics rail -->
-    <div class="logistics">
-      <div class="ll">
-        <span class="k">House</span>
-        <span class="v">45 Anchorage Way 2<small>Yarrawonga VIC 3730 · on-site parking</small></span>
-      </div>
-      <div class="ll">
-        <span class="k">Check-in</span>
-        <span class="v">From 2:00 PM Friday<small>B. Lepore &amp; C. Woods — arrange own Friday accommodation</small></span>
-      </div>
-      <div class="ll">
-        <span class="k">Tee Times</span>
-        <span class="v">Fri 12:00 · Sat 12:00 · Sun 10:00<small>Be on the practice green 20 mins prior</small></span>
-      </div>
-      <div class="ll">
-        <span class="k">Checkout</span>
-        <span class="v">Before 10:00 AM Sunday<small>After the presentations</small></span>
-      </div>
-      <div class="ll">
-        <span class="k">Provided</span>
-        <span class="v">Doona covers, pillows, kitchen &amp; cookware, BBQ, TV, WiFi<small>Sheets, pillowcases &amp; towels NOT provided</small></span>
-      </div>
-      <div class="ll">
-        <span class="k">Scores</span>
-        <span class="v">Track live on the scorecard<small>Enter scores as you play — syncs across devices</small></span>
-      </div>
-    </div>
-
-    <!-- Live scoring CTA -->
-    <a class="live-strip" href="scorecard.html">
-      <div class="l">Live Scorecard</div>
-      <div class="t">Track the Cup live from noon Friday. <em class="cap-italic">Track points, holes &amp; honours from your phone.</em></div>
-      <span class="go">Open the scorecard ↗</span>
-    </a>
-  </div>
-</section>
-
-<!-- ═══════════════════════════════════════════════════════════════════════
      FOOTER
 ═══════════════════════════════════════════════════════════════════════ -->
 <footer class="foot">
@@ -772,12 +330,10 @@
       <div class="col">
         <h5>The Tournament</h5>
         <ul>
-          <li><a href="#welcome">Welcome</a></li>
-          <li><a href="#honour">Honours</a></li>
-          <li><a href="#field">The Field</a></li>
-          <li><a href="#course">The Course</a></li>
-          <li><a href="#programme">Schedule</a></li>
-          <li><a href="#kit">Kit List</a></li>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="golfers.html">Golfers</a></li>
+          <li><a href="records.html">History &amp; Records</a></li>
+          <li><a href="practical.html">Practical Info</a></li>
           <li><a href="scorecard.html">Live Scorecard ↗</a></li>
         </ul>
       </div>
@@ -800,7 +356,7 @@
       </div>
     </div>
     <div class="colophon">
-      <div>The Wonga Cup · Inaugural Edition · 2026</div>
+      <div>The Wonga Cup · Fourth Edition · 2026</div>
       <div>Set in Cormorant &amp; Geist</div>
     </div>
   </div>
@@ -860,7 +416,6 @@ function toggleMenu() {
   btn.classList.toggle('is-open', open);
   btn.setAttribute('aria-expanded', open);
   menu.setAttribute('aria-hidden', !open);
-  // Lock page scroll while menu is open
   document.body.style.overflow = open ? 'hidden' : '';
 }
 function closeMenu() {

--- a/practical.html
+++ b/practical.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="green" data-mode="light">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Practical Info · The Wonga Cup · MMXXVI</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@300;400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<!-- Music Warning Modal -->
+<div id="music-modal" class="music-modal hidden">
+  <div class="music-modal-card">
+    <div class="music-modal-icon">🔊</div>
+    <div class="music-modal-title">⚠ WARNING</div>
+    <div class="music-modal-body">This site contains <strong>appropriate music.</strong><br><br>Click YES to agree to play music.<br><br><strong>Turn your volume all the way up.</strong></div>
+    <button class="music-yes" onclick="startMusic()">YES, I AGREE</button><br>
+    <button class="music-no" onclick="dismissMusic()">no thanks (wrong answer)</button>
+  </div>
+</div>
+<audio id="bg-audio" src="TheSong.mp3" loop preload="none" style="display:none"></audio>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     MASTHEAD
+═══════════════════════════════════════════════════════════════════════ -->
+<header class="masthead masthead--scrolled" id="masthead">
+  <div class="masthead-inner">
+    <div class="masthead-left">
+      <span>A.G.E.</span>
+      <span class="moto">·</span>
+      <span class="moto">2026</span>
+    </div>
+    <a href="index.html" class="masthead-center">A.G.E IV: The Wonga Cup</a>
+    <div class="masthead-right">
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="golfers.html">Golfers</a>
+        <a href="records.html">Records</a>
+        <a href="practical.html">Practical</a>
+        <a href="scorecard.html" class="nav-cta">Scorecard ↗</a>
+      </nav>
+      <button class="hamburger" id="hamburger" aria-label="Open menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </div>
+</header>
+
+<!-- Mobile nav -->
+<nav class="mobile-menu" id="mobile-menu" aria-hidden="true">
+  <a href="index.html" class="mm-link" onclick="closeMenu()">Home</a>
+  <a href="golfers.html" class="mm-link" onclick="closeMenu()">Golfers</a>
+  <a href="records.html" class="mm-link" onclick="closeMenu()">Records</a>
+  <a href="practical.html" class="mm-link" onclick="closeMenu()">Practical</a>
+  <a href="scorecard.html" class="mm-link mm-cta">Live Scorecard ↗</a>
+</nav>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     KIT LIST & LOGISTICS
+═══════════════════════════════════════════════════════════════════════ -->
+<section id="kit" style="padding-top:96px">
+  <div class="shell">
+    <div class="section-head">
+      <div class="meta">
+        <span>01</span>
+        <span class="num">Kit List</span>
+        <span>What to Bring</span>
+      </div>
+      <div class="title-block">
+        <h2 class="h-section">Pack like an adult. <em class="serif--italic">Play like a child.</em></h2>
+        <p class="standfirst">August in Yarrawonga: frost at sunrise, low twenties by lunch, a chance of a westerly off the lake. Pack for all three.</p>
+      </div>
+    </div>
+
+    <div class="kit-grid">
+      <div class="kit-col">
+        <h4>The Obvious</h4>
+        <ul class="kit-list">
+          <li><b>Clubs.</b> <span class="aside">A full set. Borrowing a wedge mid-round counts as a meltdown moment.</span></li>
+          <li><b>Balls.</b> <span class="aside">A dozen minimum. Two dozen if you play the lake holes the way you usually do.</span></li>
+          <li><b>Tees.</b> <span class="aside">Bring twice what you think you need.</span></li>
+          <li><b>Glove.</b> <span class="aside">Two, if there's any rain in the forecast.</span></li>
+          <li><b>Shoes.</b> <span class="aside">Spikeless or soft spikes. Pro shop is fussy.</span></li>
+        </ul>
+      </div>
+
+      <div class="kit-col">
+        <h4>On Course</h4>
+        <ul class="kit-list">
+          <li><b>Collared shirts × 3.</b> <span class="aside">Clubhouse rules. No singlets, no exceptions.</span></li>
+          <li><b>Rain jacket.</b> <span class="aside">It's August. Don't be the bloke borrowing one.</span></li>
+          <li><b>Layers.</b> <span class="aside">A puffer or vest for the early tee.</span></li>
+          <li><b>Hat.</b> <span class="aside">Cap or bucket. The Goose Hat is issued separately.</span></li>
+          <li><b>Sunscreen.</b> <span class="aside">Yes, even in August. UV doesn't read calendars.</span></li>
+          <li><b>Towel.</b> <span class="aside">For clubs. Not for crying.</span></li>
+        </ul>
+      </div>
+
+      <div class="kit-col">
+        <h4>Accommodation</h4>
+        <ul class="kit-list">
+          <li><b>Sheets &amp; pillowcases.</b> <span class="aside">Not provided — pack accordingly or air-dry.</span></li>
+          <li><b>Towels.</b> <span class="aside">Bath towels not provided.</span></li>
+          <li><b>Food &amp; drinks.</b> <span class="aside">For the house — kitchen &amp; BBQ are available.</span></li>
+          <li><b>Toiletries.</b> <span class="aside">All the usual suspects.</span></li>
+          <li><b>Warm layers.</b> <span class="aside">Yarrawonga evenings get cold in August.</span></li>
+        </ul>
+
+        <h4 style="margin-top:32px">Wallet</h4>
+        <ul class="kit-list">
+          <li><b>$200 cash.</b> <span class="aside">$100 for skins &amp; side bets. $100 for the pub.</span></li>
+          <li><b>Card.</b> <span class="aside">Accommodation, dinners, green fees, that round you owe Hughesy.</span></li>
+          <li><b>Medicare card.</b> <span class="aside">Optimistic. Possible.</span></li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Logistics rail -->
+    <div class="logistics">
+      <div class="ll">
+        <span class="k">House</span>
+        <span class="v">45 Anchorage Way 2<small>Yarrawonga VIC 3730 · on-site parking</small></span>
+      </div>
+      <div class="ll">
+        <span class="k">Check-in</span>
+        <span class="v">From 2:00 PM Friday<small>B. Lepore &amp; C. Woods — arrange own Friday accommodation</small></span>
+      </div>
+      <div class="ll">
+        <span class="k">Tee Times</span>
+        <span class="v">Fri 12:00 · Sat 12:00 · Sun 10:00<small>Be on the practice green 20 mins prior</small></span>
+      </div>
+      <div class="ll">
+        <span class="k">Checkout</span>
+        <span class="v">Before 10:00 AM Sunday<small>After the presentations</small></span>
+      </div>
+      <div class="ll">
+        <span class="k">Provided</span>
+        <span class="v">Doona covers, pillows, kitchen &amp; cookware, BBQ, TV, WiFi<small>Sheets, pillowcases &amp; towels NOT provided</small></span>
+      </div>
+      <div class="ll">
+        <span class="k">Scores</span>
+        <span class="v">Track live on the scorecard<small>Enter scores as you play — syncs across devices</small></span>
+      </div>
+    </div>
+
+    <!-- Live scoring CTA -->
+    <a class="live-strip" href="scorecard.html">
+      <div class="l">Live Scorecard</div>
+      <div class="t">Track the Cup live from noon Friday. <em class="cap-italic">Track points, holes &amp; honours from your phone.</em></div>
+      <span class="go">Open the scorecard ↗</span>
+    </a>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     FOOTER
+═══════════════════════════════════════════════════════════════════════ -->
+<footer class="foot">
+  <div class="shell">
+    <div class="row1">
+      <div class="col">
+        <h5>The Tournament</h5>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="golfers.html">Golfers</a></li>
+          <li><a href="records.html">History &amp; Records</a></li>
+          <li><a href="practical.html">Practical Info</a></li>
+          <li><a href="scorecard.html">Live Scorecard ↗</a></li>
+        </ul>
+      </div>
+      <div class="col">
+        <h5>Host Club</h5>
+        <ul>
+          <li>Yarrawonga &amp; Mulwala G.C.</li>
+          <li>Park &amp; Murray Streets</li>
+          <li>Mulwala NSW 2647</li>
+        </ul>
+      </div>
+      <div class="col">
+        <h5>Accommodation</h5>
+        <ul>
+          <li>45 Anchorage Way 2</li>
+          <li>Yarrawonga VIC 3730</li>
+          <li>Check-in from 2:00 PM, Friday</li>
+          <li>Checkout before 10:00 AM, Sunday</li>
+        </ul>
+      </div>
+    </div>
+    <div class="colophon">
+      <div>The Wonga Cup · Fourth Edition · 2026</div>
+      <div>Set in Cormorant &amp; Geist</div>
+    </div>
+  </div>
+</footer>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     THEME SWITCHER
+═══════════════════════════════════════════════════════════════════════ -->
+<div class="theme-switcher" id="theme-switcher" hidden>
+  <div class="tlabel">Coat of Paint</div>
+  <div class="row" role="radiogroup" aria-label="theme">
+    <button data-theme="green"  aria-label="green theme">Green</button>
+    <button data-theme="claret" aria-label="claret theme">Claret</button>
+    <button data-theme="navy"   aria-label="navy theme">Navy</button>
+  </div>
+  <div class="tlabel">Mode</div>
+  <div class="row" role="radiogroup" aria-label="light or dark">
+    <button data-mode="light">Light</button>
+    <button data-mode="dark">Dark</button>
+  </div>
+</div>
+
+<script src="theme.js"></script>
+<script>
+// Music consent modal
+function startMusic() {
+  document.getElementById('music-modal').classList.add('hidden');
+  sessionStorage.setItem('musicConsented', '1');
+  document.getElementById('bg-audio').play();
+}
+function dismissMusic() {
+  document.getElementById('music-modal').classList.add('hidden');
+  sessionStorage.setItem('musicConsented', 'dismissed');
+}
+if (!sessionStorage.getItem('musicConsented')) {
+  document.getElementById('music-modal').classList.remove('hidden');
+} else if (sessionStorage.getItem('musicConsented') === '1') {
+  document.getElementById('bg-audio').play();
+}
+
+// Hamburger menu
+function toggleMenu() {
+  const menu = document.getElementById('mobile-menu');
+  const btn = document.getElementById('hamburger');
+  const open = menu.classList.toggle('is-open');
+  btn.classList.toggle('is-open', open);
+  btn.setAttribute('aria-expanded', open);
+  menu.setAttribute('aria-hidden', !open);
+  document.body.style.overflow = open ? 'hidden' : '';
+}
+function closeMenu() {
+  const menu = document.getElementById('mobile-menu');
+  const btn = document.getElementById('hamburger');
+  menu.classList.remove('is-open');
+  btn.classList.remove('is-open');
+  btn.setAttribute('aria-expanded', 'false');
+  menu.setAttribute('aria-hidden', 'true');
+  document.body.style.overflow = '';
+}
+document.getElementById('hamburger').addEventListener('click', toggleMenu);
+</script>
+
+</body>
+</html>

--- a/records.html
+++ b/records.html
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="green" data-mode="light">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>History &amp; Records · The Wonga Cup · MMXXVI</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@300;400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<!-- Music Warning Modal -->
+<div id="music-modal" class="music-modal hidden">
+  <div class="music-modal-card">
+    <div class="music-modal-icon">🔊</div>
+    <div class="music-modal-title">⚠ WARNING</div>
+    <div class="music-modal-body">This site contains <strong>appropriate music.</strong><br><br>Click YES to agree to play music.<br><br><strong>Turn your volume all the way up.</strong></div>
+    <button class="music-yes" onclick="startMusic()">YES, I AGREE</button><br>
+    <button class="music-no" onclick="dismissMusic()">no thanks (wrong answer)</button>
+  </div>
+</div>
+<audio id="bg-audio" src="TheSong.mp3" loop preload="none" style="display:none"></audio>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     MASTHEAD
+═══════════════════════════════════════════════════════════════════════ -->
+<header class="masthead masthead--scrolled" id="masthead">
+  <div class="masthead-inner">
+    <div class="masthead-left">
+      <span>A.G.E.</span>
+      <span class="moto">·</span>
+      <span class="moto">2026</span>
+    </div>
+    <a href="index.html" class="masthead-center">A.G.E IV: The Wonga Cup</a>
+    <div class="masthead-right">
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="golfers.html">Golfers</a>
+        <a href="records.html">Records</a>
+        <a href="practical.html">Practical</a>
+        <a href="scorecard.html" class="nav-cta">Scorecard ↗</a>
+      </nav>
+      <button class="hamburger" id="hamburger" aria-label="Open menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </div>
+</header>
+
+<!-- Mobile nav -->
+<nav class="mobile-menu" id="mobile-menu" aria-hidden="true">
+  <a href="index.html" class="mm-link" onclick="closeMenu()">Home</a>
+  <a href="golfers.html" class="mm-link" onclick="closeMenu()">Golfers</a>
+  <a href="records.html" class="mm-link" onclick="closeMenu()">Records</a>
+  <a href="practical.html" class="mm-link" onclick="closeMenu()">Practical</a>
+  <a href="scorecard.html" class="mm-link mm-cta">Live Scorecard ↗</a>
+</nav>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     ROLL OF HONOUR
+═══════════════════════════════════════════════════════════════════════ -->
+<section id="honour" style="padding-top:96px">
+  <div class="shell">
+    <div class="section-head">
+      <div class="meta">
+        <span>01</span>
+        <span class="num">Honours</span>
+        <span>Past Champions</span>
+      </div>
+      <div class="title-block">
+        <h2 class="h-section">Three editions in, <em class="serif--italic">three different winners</em>.</h2>
+        <p class="standfirst">Started as an individual contest. Has been team-versus-team since 2024. Hasn't left Victoria yet.</p>
+      </div>
+    </div>
+
+    <div class="honour-grid">
+      <div>
+        <table class="ed-table">
+          <thead>
+            <tr><th style="width:80px">Year</th><th>Champion</th><th>Venue</th><th class="r">Margin</th></tr>
+          </thead>
+          <tbody>
+            <tr class="feat">
+              <td>2025</td>
+              <td>Team Underdogs<span class="smol">S. Rumbelow · S. Koenig · R. Hughes · N. Freestun</span></td>
+              <td>Mornington Peninsula<span class="smol">Moonah · Eagle Ridge · Devilbend</span></td>
+              <td class="r">60.5 — 38.5</td>
+            </tr>
+            <tr>
+              <td>2024</td>
+              <td>Six Foreskins<span class="smol">M. Freestun · S. Koenig · B. Lepore · C. Woods</span></td>
+              <td>Ballarat<span class="smol">Ballarat G.C. · RACV Goldfields · Buninyong</span></td>
+              <td class="r">31.5 — 21.5</td>
+            </tr>
+            <tr>
+              <td>2023</td>
+              <td>S. Koenig <em class="cap-italic muted" style="font-size:0.9em">(individual)</em><span class="smol">Inaugural — no teams contested</span></td>
+              <td>Bellarine Peninsula<span class="smol">Curlewis · Curlewis Mini · Portarlington</span></td>
+              <td class="r">+7</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <!-- Minor Awards History -->
+        <div style="margin-top:48px">
+          <h3 class="h-large" style="margin-bottom:24px">Minor Awards History</h3>
+          <table class="ed-table">
+            <thead>
+              <tr>
+                <th>Year</th>
+                <th>Longest Drive</th>
+                <th>Meltdown Medal</th>
+                <th>Pub Captain</th>
+                <th>Silly Goose Hat</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td>2023</td><td>N. Freestun 229m</td><td class="tag">N/A</td><td>R. Hughes</td><td class="tag">Not introduced</td></tr>
+              <tr><td>2024</td><td>M. Freestun 255m</td><td>S. Rumbelow</td><td>R. Hughes</td><td class="tag">Not introduced</td></tr>
+              <tr><td>2025</td><td>G. King 272m</td><td>N. Freestun</td><td>R. Hughes</td><td>G. King</td></tr>
+              <tr><td>2026</td><td class="tag">TBD</td><td class="tag">TBD</td><td class="tag">TBD</td><td class="tag">TBD</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div>
+        <div class="honour-photo" style="background-image:url('images/teams-photo.png');background-position:center 20%"></div>
+        <div class="cap">Defending Champions · Team Underdogs, Moonah Links 2025</div>
+
+        <!-- Records -->
+        <div style="margin-top:40px">
+          <h3 class="h-large" style="margin-bottom:16px">All-Time Records</h3>
+          <div class="records" style="grid-template-columns:1fr">
+            <div class="col">
+              <h4>Most Appearances</h4>
+              <div class="row"><div class="n">3</div><div class="who">J. McIntyre · M. Freestun · N. Freestun · R. Hughes · S. Rumbelow · S. Koenig</div></div>
+            </div>
+            <div class="col" style="margin-top:16px">
+              <h4>Most Team Wins</h4>
+              <div class="row"><div class="n">2</div><div class="who">S. Koenig</div></div>
+              <div class="row"><div class="n">1</div><div class="who">M. Freestun · N. Freestun · R. Hughes · S. Rumbelow · B. Lepore · C. Woods</div></div>
+              <div class="row"><div class="n muted">0</div><div class="who muted">J. McIntyre · B. Cunningham · G. King</div></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     TROPHIES ON OFFER
+═══════════════════════════════════════════════════════════════════════ -->
+<section id="trophies" class="alt">
+  <div class="shell shell--wide">
+    <div class="section-head">
+      <div class="meta">
+        <span>02</span>
+        <span class="num">Trophies</span>
+        <span>On the Line</span>
+      </div>
+      <div class="title-block">
+        <h2 class="h-section">One Cup. <em class="serif--italic">Six side honours.</em></h2>
+        <p class="standfirst">The Wonga Cup is contested between sides. The six minor honours are decided across individuals, hole records, and the verdict of a Pub Captain whose tenure is yet to be challenged.</p>
+      </div>
+    </div>
+
+    <div class="awards">
+      <div class="award">
+        <span class="l">Cup</span>
+        <span class="name">The <em>Wonga</em> Cup</span>
+        <p>Awarded to the winning side across all three days. Bragging rights until the following August.</p>
+        <span class="holder">Holders · Team Underdogs '25</span>
+      </div>
+      <div class="award">
+        <span class="l">Minor</span>
+        <span class="name">Longest <em>Drive</em></span>
+        <p>Furthest measured drive on the nominated hole. Carts ineligible.</p>
+        <span class="holder">Holder · G. King · 272m</span>
+      </div>
+      <div class="award">
+        <span class="l">Minor</span>
+        <span class="name">Nearest the <em>Pin</em></span>
+        <p>Closest tee shot to the flag on the nominated par 3.</p>
+        <span class="holder">Holder · vacant</span>
+      </div>
+      <div class="award">
+        <span class="l">Minor</span>
+        <span class="name">The <em>Silly Goose</em> Hat</span>
+        <p>For the single most baffling decision made on a golf course across the weekend.</p>
+        <span class="holder">Holder · G. King</span>
+      </div>
+      <div class="award">
+        <span class="l">Minor</span>
+        <span class="name">Worst <em>Blow-Up</em></span>
+        <p>Highest single-hole score in the tournament. A badge of honour for the genuinely cursed.</p>
+        <span class="holder">Holder · S. Rumbelow · −13</span>
+      </div>
+      <div class="award">
+        <span class="l">Minor</span>
+        <span class="name">The <em>Meltdown</em> Medal</span>
+        <p>For the most spectacular loss of composure observed on the course.</p>
+        <span class="holder">Holder · N. Freestun</span>
+      </div>
+      <div class="award">
+        <span class="l">Minor</span>
+        <span class="name">Pub Captain's <em>Choice</em></span>
+        <p>The wildcard. Awarded by the Pub Captain on merit or entertainment, whichever applies.</p>
+        <span class="holder">Holder · R. Hughes ×3</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     ALL-TIME RECORDS
+═══════════════════════════════════════════════════════════════════════ -->
+<section id="records" class="dense">
+  <div class="shell">
+    <div class="section-head">
+      <div class="meta">
+        <span>03</span>
+        <span class="num">Records</span>
+        <span>All-Time</span>
+      </div>
+      <div class="title-block">
+        <h2 class="h-section">Three editions in. <em class="serif--italic">The book starts to write itself.</em></h2>
+      </div>
+    </div>
+
+    <div class="records">
+      <div class="col">
+        <h4>Most Appearances</h4>
+        <div class="row"><div class="n">III</div><div class="who">J. McIntyre · M. Freestun · N. Freestun · R. Hughes · S. Rumbelow · S. Koenig</div></div>
+        <div class="row"><div class="n">II</div><div class="who">G. King · B. Cunningham</div></div>
+        <div class="row"><div class="n">I</div><div class="who">B. Lepore · C. Woods</div></div>
+      </div>
+
+      <div class="col">
+        <h4>Most Team Victories</h4>
+        <div class="row"><div class="n">II</div><div class="who">S. Koenig</div></div>
+        <div class="row"><div class="n">I</div><div class="who">M. Freestun · N. Freestun · R. Hughes · S. Rumbelow · B. Lepore · C. Woods</div></div>
+        <div class="row"><div class="n muted">0</div><div class="who muted">J. McIntyre · B. Cunningham · G. King</div></div>
+      </div>
+
+      <div class="col">
+        <h4>Career Numbers</h4>
+        <div class="row"><div class="n">272m</div><div class="who">Longest measured drive · G. King · 2025</div></div>
+        <div class="row"><div class="n">−7</div><div class="who">Inaugural weekend medal · S. Koenig · 2023</div></div>
+        <div class="row"><div class="n">36–7</div><div class="who">Largest Stableford margin on a single round · 2025</div></div>
+        <div class="row"><div class="n">×3</div><div class="who">R. Hughes — Pub Captain's Choice, every edition</div></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     FOOTER
+═══════════════════════════════════════════════════════════════════════ -->
+<footer class="foot">
+  <div class="shell">
+    <div class="row1">
+      <div class="col">
+        <h5>The Tournament</h5>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="golfers.html">Golfers</a></li>
+          <li><a href="records.html">History &amp; Records</a></li>
+          <li><a href="practical.html">Practical Info</a></li>
+          <li><a href="scorecard.html">Live Scorecard ↗</a></li>
+        </ul>
+      </div>
+      <div class="col">
+        <h5>Host Club</h5>
+        <ul>
+          <li>Yarrawonga &amp; Mulwala G.C.</li>
+          <li>Park &amp; Murray Streets</li>
+          <li>Mulwala NSW 2647</li>
+        </ul>
+      </div>
+      <div class="col">
+        <h5>Accommodation</h5>
+        <ul>
+          <li>45 Anchorage Way 2</li>
+          <li>Yarrawonga VIC 3730</li>
+          <li>Check-in from 2:00 PM, Friday</li>
+          <li>Checkout before 10:00 AM, Sunday</li>
+        </ul>
+      </div>
+    </div>
+    <div class="colophon">
+      <div>The Wonga Cup · Fourth Edition · 2026</div>
+      <div>Set in Cormorant &amp; Geist</div>
+    </div>
+  </div>
+</footer>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     THEME SWITCHER
+═══════════════════════════════════════════════════════════════════════ -->
+<div class="theme-switcher" id="theme-switcher" hidden>
+  <div class="tlabel">Coat of Paint</div>
+  <div class="row" role="radiogroup" aria-label="theme">
+    <button data-theme="green"  aria-label="green theme">Green</button>
+    <button data-theme="claret" aria-label="claret theme">Claret</button>
+    <button data-theme="navy"   aria-label="navy theme">Navy</button>
+  </div>
+  <div class="tlabel">Mode</div>
+  <div class="row" role="radiogroup" aria-label="light or dark">
+    <button data-mode="light">Light</button>
+    <button data-mode="dark">Dark</button>
+  </div>
+</div>
+
+<script src="theme.js"></script>
+<script>
+// Music consent modal
+function startMusic() {
+  document.getElementById('music-modal').classList.add('hidden');
+  sessionStorage.setItem('musicConsented', '1');
+  document.getElementById('bg-audio').play();
+}
+function dismissMusic() {
+  document.getElementById('music-modal').classList.add('hidden');
+  sessionStorage.setItem('musicConsented', 'dismissed');
+}
+if (!sessionStorage.getItem('musicConsented')) {
+  document.getElementById('music-modal').classList.remove('hidden');
+} else if (sessionStorage.getItem('musicConsented') === '1') {
+  document.getElementById('bg-audio').play();
+}
+
+// Hamburger menu
+function toggleMenu() {
+  const menu = document.getElementById('mobile-menu');
+  const btn = document.getElementById('hamburger');
+  const open = menu.classList.toggle('is-open');
+  btn.classList.toggle('is-open', open);
+  btn.setAttribute('aria-expanded', open);
+  menu.setAttribute('aria-hidden', !open);
+  document.body.style.overflow = open ? 'hidden' : '';
+}
+function closeMenu() {
+  const menu = document.getElementById('mobile-menu');
+  const btn = document.getElementById('hamburger');
+  menu.classList.remove('is-open');
+  btn.classList.remove('is-open');
+  btn.setAttribute('aria-expanded', 'false');
+  menu.setAttribute('aria-hidden', 'true');
+  document.body.style.overflow = '';
+}
+document.getElementById('hamburger').addEventListener('click', toggleMenu);
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
- index.html: Home (Welcome, Course, Schedule)
- golfers.html: The twelve starters
- records.html: Roll of Honour, Trophies, All-Time Records
- practical.html: Kit list, logistics, accommodation
- scorecard.html: unchanged

Nav and footer updated across all pages to link between them.

https://claude.ai/code/session_0142nwsYnD1ZoLSDQN9xYnFt