### PR TITLE
Switch team format from pre-set handicap split to Captain's Draft

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
       </div>
       <div class="col">
         <span>Field</span>
-        <span class="v">Twelve Starters · Six per Side</span>
+        <span class="v">Twelve Starters · Captain's Draft</span>
       </div>
       <div class="col">
         <span>Format</span>
@@ -146,7 +146,7 @@
         </div>
         <div class="stat">
           <div class="k">Starters</div>
-          <div class="v">12<small>two sides of six</small></div>
+          <div class="v">12<small>Captain's Draft</small></div>
         </div>
         <div class="stat">
           <div class="k">Holes Played</div>
@@ -274,9 +274,10 @@
         <div class="what">
           <div class="frm">Match Play Best Ball · 10 players · Murray Course</div>
           <h3>The first ten arrivals tee off at noon. One singles, two doubles per side.</h3>
-          <p>Two doubles, one singles - 3 matches, 6 points up for grabs. 2pts per match win, 1pt each for all square. Cayden Woods &amp; Ben Lepore join the field Saturday morning.</p>
+          <p>Teams are set by Captain's Draft on Friday morning — the two peer-vote captains pick in snake order until all players are assigned. Two doubles, one singles - 3 matches, 6 points up for grabs. 2pts per match win, 1pt each for all square. Cayden Woods &amp; Ben Lepore join the field Saturday morning.</p>
         </div>
         <div class="runs">
+          <div class="item"><div class="t">Morning</div><div class="x">Captain's Draft · teams drawn before tee-off<em>Peer vote captains; snake draft fills the sides</em></div></div>
           <div class="item"><div class="t">12:00</div><div class="x">Tee off · Murray Course<em>Be on the practice green by 11:30</em></div></div>
           <div class="item"><div class="t">14:00</div><div class="x">Check-in opens · 45 Anchorage Way 2<em>Keys held at reception until 7:00 PM</em></div></div>
           <div class="item"><div class="t">Evening</div><div class="x">Team dinner · venue TBC<em>Scores settled, stories started</em></div></div>

--- a/scorecard-live.html
+++ b/scorecard-live.html
@@ -388,7 +388,7 @@ body{padding-bottom:52px}
         <div class="section-label">Setup</div>
         <div class="section-title">Team Assignment</div>
       </div>
-      <div class="info-box">Adjust team assignments as needed. Click "→ B" or "← A" to move a player.</div>
+      <div class="info-box">Enter the Captain's Draft result here — assign each player to their team using the arrows below. Teams are unknown until the morning of Day 1.</div>
       <div class="team-setup-grid">
         <div class="team-col team-a-col">
           <div class="team-col-h" id="team-col-h-a">Team Beer</div>
@@ -399,7 +399,7 @@ body{padding-bottom:52px}
           <div id="team-b-list"></div>
         </div>
       </div>
-      <button onclick="resetTeams()" style="padding:10px 22px;font-family:var(--font-h);font-size:.8rem;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;background:transparent;border:1px solid var(--rule-strong);color:var(--ink-mute);border-radius:var(--r);cursor:pointer">Reset to Default</button>
+      <button onclick="resetTeams()" style="padding:10px 22px;font-family:var(--font-h);font-size:.8rem;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;background:transparent;border:1px solid var(--rule-strong);color:var(--ink-mute);border-radius:var(--r);cursor:pointer">Clear Teams</button>
     </div>
 
     <!-- ── DAY 1 PANEL ── -->
@@ -543,8 +543,9 @@ const PLAYERS = [
 ];
 
 // TEST TEAMS — replace with real draft outcome before go-live
-const DEFAULT_A = new Set([0, 2, 4, 6, 8, 10, 12]); // even-indexed IDs → Team A
-const DEFAULT_B = new Set([1, 3, 5, 7, 9, 11, 13]); // odd-indexed IDs → Team B
+// Teams determined by Captain's Draft on Friday morning — no defaults
+const DEFAULT_A = new Set();
+const DEFAULT_B = new Set();
 
 /* ─────────────────────────────────────
    STATE


### PR DESCRIPTION
- index.html: update hero field stat and starters callout from "six per side"
  to "Captain's Draft"; add Captain's Draft to Friday morning schedule;
  mention peer-vote captains + snake draft in Friday format description
- scorecard.html: clear DEFAULT_A/B so players start unassigned; update
  Team Assignment info box to explain draft entry; rename "Reset to Default"
  button to "Clear Teams"

Closes #37

https://claude.ai/code/session_0193yr7sEfppMRoPrV3n6Zfm