### PR TITLE
Fix missed 12-player reference in Lake Course format description (index.html)

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@
         <p>The shorter overall length makes it the ideal Stableford closer: higher handicappers can post solid scores when the bunkers are avoided, but the sand traps are everywhere and they claim ambition regularly.</p>
         <div class="signature">
           <div class="l">Format · Individual Net Stableford</div>
-          <div class="v">All 12 players. Points by finishing position: 1st=12, 2nd=10, 3rd=9 … down to 12th=0. Tied players share averaged points. Each player's points go to their team total.</div>
+          <div class="v">All 14 players. Points by finishing position: 1st=14, 2nd=12, 3rd=11 … down to 14th=0. Tied players share averaged points. Each player's points go to their team total.</div>
         </div>
       </div>
     </article>


### PR DESCRIPTION
The PR #42 pass missed the Lake Course signature line which still read
"All 12 players … 1st=12 down to 12th=0". Updated to 14-player scale.

Closes #36

https://claude.ai/code/session_012DTLwt2dEGrWbo1HVoHscS