### PR TITLE
Restore scorecard.html placeholder (issue #38 regression fix)

### DIFF
--- a/scorecard-live.html
+++ b/scorecard-live.html
@@ -545,9 +545,8 @@ const PLAYERS = [
 ];
 
 // TEST TEAMS — replace with real draft outcome before go-live
-// Teams determined by Captain's Draft on Friday morning — no defaults
-const DEFAULT_A = new Set();
-const DEFAULT_B = new Set();
+const DEFAULT_A = new Set([0, 2, 4, 6, 8, 10, 12]); // even-indexed IDs → Team A
+const DEFAULT_B = new Set([1, 3, 5, 7, 9, 11, 13]); // odd-indexed IDs → Team B
 
 /* ─────────────────────────────────────
    STATE

--- a/scorecard.html
+++ b/scorecard.html
@@ -2,253 +2,154 @@
 <html lang="en" data-theme="green" data-mode="light">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Live Scorecard · The Wonga Cup 2026</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Scorecard · The Wonga Cup · MMXXVI</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@300;400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="styles.css">
-<link rel="stylesheet" href="scorecard.css">
 <style>
-:root {
-  /* scoring area — always dark regardless of theme */
-  --navy:#0b1a0d; --navy-light:#162e18; --navy-mid:#1c3a20;
-  --card-bg:#132415;
-  /* warm cream text to match design system canvas */
-  --white:#efe7d3; --off-white:#e6dcc4;
-  --fairway:#2d6a4f; --fairway-dark:#1a4731;
-  --grey:#8a9b8d; --light-grey:#d4e0d6;
-  /* accents follow design system theme token */
-  --gold:var(--accent-2, #b08d4f);
-  --gold-dark:var(--accent, #876531);
-  --gold-light:#c9a96a;
-  /* team A tracks the theme accent; team B stays blue */
-  --team-a:var(--accent-2, #b08d4f); --team-b:#6ab8f7;
-  /* typography from design system */
-  --font-d:var(--display,'Cormorant Garamond',Georgia,serif);
-  --font-h:var(--mono,'Geist Mono',monospace);
-  --font-b:var(--body,'Geist',sans-serif);
-  --tr:all .22s ease; --r:8px; --rl:16px;
+.draft-hero {
+  padding: 96px 0 64px;
+  text-align: center;
 }
-
-/* ── SCORECARD PAGE ── */
-.scoreboard-pin{position:sticky;top:58px;z-index:900;background:linear-gradient(90deg,var(--navy),var(--navy-mid),var(--navy));border-bottom:3px solid var(--gold)}
-.scoreboard-inner{max-width:1200px;margin:0 auto;padding:14px 24px;display:grid;grid-template-columns:1fr 80px 1fr;align-items:center;gap:12px}
-.sb-team{text-align:center}
-.sb-team-name{font-family:var(--font-h);font-size:.68rem;font-weight:600;letter-spacing:3px;text-transform:uppercase;margin-bottom:2px}
-.sb-total{font-family:var(--font-d);font-size:3.2rem;line-height:1}
-.team-a .sb-team-name,.team-a .sb-total{color:var(--team-a)}
-.team-b .sb-team-name,.team-b .sb-total{color:var(--team-b)}
-.sb-vs{font-family:var(--font-d);font-size:1.4rem;color:var(--grey);text-align:center}
-.sb-day-chips{display:flex;justify-content:center;gap:6px;margin-top:5px;flex-wrap:wrap}
-.sb-chip{font-family:var(--font-h);font-size:.6rem;font-weight:600;letter-spacing:1px;text-transform:uppercase;padding:2px 8px;border-radius:4px;background:rgba(255,255,255,.06);color:var(--grey)}
-.win-banner{background:linear-gradient(90deg,var(--gold-dark),var(--gold),var(--gold-dark));color:var(--navy);text-align:center;padding:11px 24px;font-family:var(--font-d);font-size:1.4rem;letter-spacing:2px;animation:pulse 2s ease-in-out infinite}
-.sd-banner{background:linear-gradient(90deg,#7a0000,#c00,#7a0000);color:var(--white);text-align:center;padding:11px 24px;font-family:var(--font-d);font-size:1.4rem;letter-spacing:2px;animation:pulse 1.4s ease-in-out infinite}
-@keyframes pulse{0%,100%{opacity:1}50%{opacity:.82}}
-.photo-banner{width:100%;max-height:340px;object-fit:cover;border-radius:var(--rl);margin-bottom:24px;display:block}
-.photo-pair{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:24px}
-.photo-pair img{width:100%;height:200px;object-fit:cover;border-radius:var(--r)}
-@media(max-width:600px){.photo-pair{grid-template-columns:1fr}}
-.refresh-btn{background:rgba(240,180,41,.15);color:var(--gold);border:1px solid var(--gold);padding:8px 14px;border-radius:var(--r);font-family:var(--font-h);font-size:.75rem;font-weight:600;letter-spacing:1px;text-transform:uppercase;cursor:pointer;transition:var(--tr)}
-.refresh-btn:hover{background:rgba(240,180,41,.25)}
-
-/* ── SC TABS ── */
-.sc-tabs{display:flex;gap:2px;border-bottom:2px solid var(--rule-strong);max-width:1200px;margin:0 auto;padding:20px 24px 0;background:var(--canvas)}
-.sc-tab{padding:10px 18px;font-family:var(--font-h);font-size:.8rem;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:var(--ink-mute);background:transparent;border:none;border-bottom:3px solid transparent;cursor:pointer;transition:var(--tr);margin-bottom:-2px}
-.sc-tab:hover{color:var(--ink)}
-.sc-tab.active{color:var(--gold);border-bottom-color:var(--gold)}
-.sc-panel{display:none}
-.sc-panel.active{display:block}
-
-/* ── TEAM SETUP ── */
-.team-setup-grid{display:grid;grid-template-columns:1fr 1fr;gap:24px;margin-bottom:24px}
-.team-col{background:var(--canvas);border:2px solid;border-radius:var(--rl);padding:20px}
-.team-a-col{border-color:rgba(240,180,41,.5)}
-.team-b-col{border-color:rgba(74,158,255,.5)}
-.team-col-h{font-family:var(--font-d);font-size:1.7rem;margin-bottom:14px}
-.team-a-col .team-col-h{color:var(--team-a)}
-.team-b-col .team-col-h{color:var(--team-b)}
-.team-player-item{display:flex;justify-content:space-between;align-items:center;padding:9px 13px;border-radius:var(--r);background:var(--canvas-2);margin-bottom:6px}
-.team-player-item span{color:var(--ink);font-size:.9rem}
-.team-player-item small{color:var(--ink-mute);font-size:.8rem}
-.move-btn{padding:4px 11px;font-family:var(--font-h);font-size:.68rem;font-weight:600;letter-spacing:1px;text-transform:uppercase;border:1px solid var(--rule-strong);background:transparent;color:var(--ink-mute);border-radius:4px;cursor:pointer;transition:var(--tr)}
-.move-btn:hover{background:var(--canvas-2);color:var(--ink)}
-@media(max-width:700px){.team-setup-grid{grid-template-columns:1fr}}
-
-/* ── MATCH CARDS ── */
-.match-card{background:var(--canvas);border:1px solid var(--rule);border-radius:var(--rl);margin-bottom:20px;overflow:hidden;transition:border-color .3s,box-shadow .3s}
-.match-card.win-a{border-color:color-mix(in srgb,var(--team-a) 60%,transparent);box-shadow:0 0 20px color-mix(in srgb,var(--team-a) 15%,transparent);border-left:4px solid var(--team-a)}
-.match-card.win-b{border-color:color-mix(in srgb,var(--team-b) 60%,transparent);box-shadow:0 0 20px color-mix(in srgb,var(--team-b) 15%,transparent);border-left:4px solid var(--team-b)}
-.match-card.win-as{border-color:var(--rule-strong);border-left:4px solid var(--rule-strong)}
-.match-header{background:var(--canvas-2);border-bottom:1px solid var(--rule);padding:14px 22px;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:10px}
-.match-title{font-family:var(--font-d);font-size:1.4rem;letter-spacing:1px;color:var(--ink)}
-.match-score-display{font-family:var(--font-d);font-size:1.7rem;display:flex;align-items:center;gap:6px}
-.msa{color:var(--team-a)}
-.msb{color:var(--team-b)}
-.mss{color:var(--ink-mute);font-size:1.1rem}
-.match-players-row{padding:14px 22px;border-bottom:1px solid var(--rule);display:grid;grid-template-columns:1fr auto 1fr;gap:12px;align-items:center}
-.player-group{display:flex;flex-direction:column;gap:6px}
-.player-group.pb{align-items:flex-end}
-.pg-label{font-family:var(--font-h);font-size:.65rem;font-weight:600;letter-spacing:2px;text-transform:uppercase;margin-bottom:2px}
-.pgl-a{color:var(--team-a)}
-.pgl-b{color:var(--team-b)}
-.vs-div{font-family:var(--font-h);font-size:.75rem;font-weight:700;letter-spacing:2px;color:var(--ink-mute);text-align:center}
-select{background:var(--canvas);border:1px solid var(--rule-strong);border-radius:var(--r);color:var(--ink);padding:7px 10px;font-family:var(--font-b);font-size:.83rem;width:100%;cursor:pointer}
-select:focus{outline:none;border-color:var(--gold)}
-select option{background:var(--canvas)}
-
-/* ── HOLE GRID ── */
-.hole-grid-wrap{padding:18px 22px 22px;overflow-x:auto}
-.hole-grid{display:grid;grid-template-columns:repeat(18,1fr);gap:3px;min-width:580px}
-.hole-cell{display:flex;flex-direction:column;align-items:center;gap:3px}
-.hole-num{font-family:var(--font-h);font-size:.58rem;font-weight:600;color:var(--ink-mute)}
-.hole-btn{width:28px;height:20px;font-family:var(--font-h);font-size:.62rem;font-weight:700;border:1px solid var(--rule-strong);border-radius:3px;cursor:pointer;background:var(--canvas-2);color:var(--ink-mute);transition:var(--tr)}
-.hole-btn:hover{opacity:.8}
-.hole-btn.ha{background:var(--team-a);color:#fff;border-color:var(--team-a)}
-.hole-btn.hh{background:var(--rule-strong);color:var(--ink);border-color:var(--rule-strong)}
-.hole-btn.hb{background:var(--team-b);color:#fff;border-color:var(--team-b)}
-.running-score-row{display:flex;justify-content:space-between;align-items:center;padding:0 22px 14px;font-family:var(--font-h);font-size:.78rem;font-weight:600;letter-spacing:1px;flex-wrap:wrap;gap:8px}
-.rs-label{color:var(--ink-mute);text-transform:uppercase}
-
-/* ── DAY 2 ── */
-.scramble-grid{display:grid;grid-template-columns:1fr 1fr;gap:24px}
-@media(max-width:700px){.scramble-grid{grid-template-columns:1fr}}
-.scramble-team-card{background:var(--canvas);border:2px solid;border-radius:var(--rl);padding:24px}
-.scramble-team-a{border-color:color-mix(in srgb,var(--team-a) 40%,transparent);transition:border-color .3s,background .3s,box-shadow .3s}
-.scramble-team-b{border-color:color-mix(in srgb,var(--team-b) 40%,transparent);transition:border-color .3s,background .3s,box-shadow .3s}
-.scramble-team-a.leading{border-color:var(--team-a);background:color-mix(in srgb,var(--team-a) 8%,var(--canvas));box-shadow:0 0 24px color-mix(in srgb,var(--team-a) 12%,transparent)}
-.scramble-team-b.leading{border-color:var(--team-b);background:color-mix(in srgb,var(--team-b) 8%,var(--canvas));box-shadow:0 0 24px color-mix(in srgb,var(--team-b) 12%,transparent)}
-.scramble-team-title{font-family:var(--font-d);font-size:1.55rem;margin-bottom:18px}
-.scramble-team-a .scramble-team-title{color:var(--team-a)}
-.scramble-team-b .scramble-team-title{color:var(--team-b)}
-.sig{margin-bottom:14px}
-.sig label{display:block;font-family:var(--font-h);font-size:.72rem;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:var(--ink-mute);margin-bottom:7px}
-.sig-row{display:flex;align-items:center;gap:12px}
-.sig-row input{min-height:44px;min-width:80px;font-size:1rem}
-input[type=number]{background:var(--canvas-2);border:1px solid var(--rule-strong);border-radius:var(--r);color:var(--ink);padding:9px 12px;font-family:var(--font-d);font-size:1.35rem;width:90px;text-align:center}
-input[type=number]:focus{outline:none;border-color:var(--gold)}
-.pts-badge{font-family:var(--font-d);font-size:1.35rem;color:var(--ink-mute)}
-.pts-badge.live{color:var(--gold)}
-.day-total-row{background:color-mix(in srgb,var(--gold) 8%,transparent);border:1px solid color-mix(in srgb,var(--gold) 20%,transparent);border-radius:var(--r);padding:11px 15px;margin-top:14px;font-family:var(--font-h);font-weight:600;letter-spacing:1px;display:flex;justify-content:space-between}
-.day-total-row .lbl{color:var(--ink-mute);font-size:.78rem;text-transform:uppercase}
-.day-total-row .val{font-size:1.05rem}
-.scramble-team-a .day-total-row .val{color:var(--team-a)}
-.scramble-team-b .day-total-row .val{color:var(--team-b)}
-
-/* ── DAY 3 ── */
-.sf-table-wrap{background:var(--canvas);border:1px solid var(--rule);border-radius:var(--rl);overflow-x:auto;-webkit-overflow-scrolling:touch}
-.sf-table{width:100%;min-width:480px;border-collapse:collapse}
-.sf-table th{background:var(--canvas-2);font-family:var(--font-h);font-size:.68rem;font-weight:600;letter-spacing:2px;text-transform:uppercase;padding:11px 14px;text-align:left;color:var(--ink-mute);border-bottom:1px solid var(--rule-strong)}
-.sf-table td{padding:9px 14px;border-bottom:1px solid var(--rule);font-size:.9rem;color:var(--ink)}
-.sf-table tr:last-child td{border-bottom:none}
-.pos-cell{font-family:var(--font-d);font-size:1.25rem;color:var(--ink-mute);text-align:center;width:44px}
-.pos-1{color:var(--gold)!important}
-.pos-2{color:#c0c0c0!important}
-.pos-3{color:#cd7f32!important}
-.pts-cell{font-family:var(--font-d);font-size:1.45rem;text-align:right}
-.row-a .pts-cell{color:var(--team-a)}
-.row-b .pts-cell{color:var(--team-b)}
-.row-a.top-scorer{background:color-mix(in srgb,var(--team-a) 7%,transparent);border-left:3px solid var(--team-a)}
-.row-b.top-scorer{background:color-mix(in srgb,var(--team-b) 7%,transparent);border-left:3px solid var(--team-b)}
-input[type=number].sf-in{width:76px;padding:5px 9px;font-size:1.05rem}
-.team-badge{font-family:var(--font-h);font-size:.65rem;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;padding:2px 9px;border-radius:100px}
-.ta-badge{background:color-mix(in srgb,var(--team-a) 15%,transparent);color:var(--team-a);border:1px solid color-mix(in srgb,var(--team-a) 40%,transparent)}
-.tb-badge{background:color-mix(in srgb,var(--team-b) 15%,transparent);color:var(--team-b);border:1px solid color-mix(in srgb,var(--team-b) 40%,transparent)}
-
-/* ── UTILS ── */
-.gold{color:var(--gold)}
-.grey{color:var(--ink-mute)}
-.mt8{margin-top:8px}.mt16{margin-top:16px}.mt24{margin-top:24px}.mt32{margin-top:32px}
-.mb16{margin-bottom:16px}.mb24{margin-bottom:24px}
-.tc{text-align:center}
-@keyframes pop{0%{transform:scale(1)}50%{transform:scale(1.12)}100%{transform:scale(1)}}
-.pop{animation:pop .28s ease}
-.info-box{background:color-mix(in srgb,var(--gold) 8%,transparent);border:1px solid color-mix(in srgb,var(--gold) 20%,transparent);border-radius:var(--r);padding:14px 18px;font-size:.88rem;color:var(--ink);margin-bottom:20px}
-.info-box strong{color:var(--gold)}
-
-/* ── COURSE IMAGES ── */
-.course-img-frame{position:relative;overflow:hidden;border-bottom:2px solid rgba(45,106,79,.5)}
-.course-img{width:100%;height:200px;object-fit:cover;display:none}
-.course-img.loaded{display:block}
-.course-ph{width:100%;height:200px;background:linear-gradient(135deg,var(--fairway-dark) 0%,var(--navy-mid) 100%);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:10px}
-.course-ph-icon{font-size:2.8rem;opacity:.6}
-.course-ph-label{font-family:var(--font-d);font-size:1.1rem;letter-spacing:3px;color:rgba(255,255,255,.35);text-transform:uppercase}
-.course-ph-sub{font-family:var(--font-h);font-size:.65rem;letter-spacing:2px;text-transform:uppercase;color:rgba(255,255,255,.2)}
-
-/* ── LIVE SYNC BAR ── */
-.sync-bar{max-width:1200px;margin:0 auto;padding:10px 24px;display:flex;align-items:center;gap:10px;flex-wrap:wrap;border-bottom:1px solid var(--rule);background:var(--canvas-2)}
-.sync-label{font-family:var(--font-h);font-size:.7rem;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:var(--ink-mute);display:flex;align-items:center;gap:6px}
-.live-dot{width:8px;height:8px;border-radius:50%;background:#44dd88;animation:blink 1.5s ease-in-out infinite;display:inline-block}
-@keyframes blink{0%,100%{opacity:1}50%{opacity:.25}}
-.sync-btn{padding:7px 16px;font-family:var(--font-h);font-size:.75rem;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;background:var(--gold);color:#0b1a0d;border:none;border-radius:var(--r);cursor:pointer;transition:var(--tr)}
-.sync-btn:hover{background:var(--gold-light)}
-.sync-btn.sec{background:transparent;color:var(--ink-mute);border:1px solid var(--rule-strong)}
-.sync-btn.sec:hover{color:var(--ink);border-color:var(--ink-mute)}
-.save-toast{position:fixed;bottom:24px;left:24px;font-family:var(--font-h);font-size:.75rem;font-weight:600;letter-spacing:1px;text-transform:uppercase;padding:12px 16px;border-radius:var(--r);opacity:0;transition:opacity .3s;pointer-events:none;z-index:100}
-.save-toast.show{opacity:1}
-.save-toast.saving{background:rgba(240,180,41,.2);color:var(--gold);border:1px solid var(--gold)}
-.save-toast.success{background:rgba(68,221,136,.2);color:#44dd88;border:1px solid #44dd88}
-.save-toast.error{background:rgba(220,0,0,.2);color:#ff6b6b;border:1px solid #ff6b6b}
-.sync-spacer{flex:1}
-
-/* ── USERNAME PICKER MODAL ── */
-.username-modal{position:fixed;inset:0;background:rgba(0,0,0,.7);display:flex;align-items:center;justify-content:center;z-index:9999;backdrop-filter:blur(4px)}
-.username-modal.hidden{display:none}
-.username-modal-card{background:var(--canvas);border:2px solid var(--gold);border-radius:var(--rl);padding:40px;max-width:400px;text-align:center;box-shadow:0 20px 60px rgba(0,0,0,.3)}
-.username-modal-title{font-family:var(--font-d);font-size:2rem;letter-spacing:2px;color:var(--gold);margin-bottom:8px}
-.username-modal-desc{font-size:.95rem;color:var(--ink-mute);margin-bottom:24px}
-.username-input{width:100%;padding:12px 16px;font-family:var(--font-b);font-size:1rem;border:1px solid var(--rule-strong);border-radius:var(--r);background:var(--canvas-2);color:var(--ink);margin-bottom:16px;transition:var(--tr)}
-.username-input:focus{outline:none;border-color:var(--gold);background:var(--canvas)}
-.username-input::placeholder{color:var(--ink-mute)}
-.username-btn{width:100%;padding:12px 20px;font-family:var(--font-h);font-size:.9rem;font-weight:600;letter-spacing:2px;text-transform:uppercase;background:var(--gold);color:#0b1a0d;border:none;border-radius:var(--r);cursor:pointer;transition:var(--tr)}
-.username-btn:hover{background:var(--gold-light)}
-.username-btn:disabled{opacity:.5;cursor:not-allowed}
-.username-badge{position:fixed;top:64px;right:24px;font-family:var(--font-h);font-size:.75rem;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:var(--gold);background:rgba(240,180,41,.12);border:1px solid rgba(240,180,41,.3);padding:6px 14px;border-radius:100px;z-index:100}
-.offline-banner{position:fixed;top:108px;right:24px;background:rgba(200,0,0,.9);color:#efe7d3;padding:8px 16px;border-radius:var(--r);font-family:var(--font-h);font-size:.8rem;font-weight:600;letter-spacing:1px;text-transform:uppercase;z-index:999;animation:slideIn .3s ease}
-@keyframes slideIn{from{transform:translateX(400px);opacity:0}to{transform:translateX(0);opacity:1}}
-
-/* ── MINI SCOREBOARD ── */
-.mini-sb{background:rgba(11,26,13,.97);border-bottom:1px solid rgba(240,180,41,.2);padding:7px 24px;display:flex;align-items:center;justify-content:center;gap:16px;flex-wrap:wrap}
-.mini-sb-team{display:flex;align-items:center;gap:8px;font-family:var(--font-h);font-size:.72rem;font-weight:600;letter-spacing:1.5px;text-transform:uppercase}
-.mini-sb-name{color:var(--grey)}
-.mini-sb-score{font-family:var(--font-d);font-size:1.4rem;line-height:1}
-.mini-sb-a .mini-sb-score{color:var(--team-a)}
-.mini-sb-b .mini-sb-score{color:var(--team-b)}
-.mini-sb-vs{font-family:var(--font-d);font-size:.9rem;color:var(--grey)}
-.mini-sb-days{display:flex;gap:6px}
-.mini-sb-chip{font-family:var(--font-h);font-size:.6rem;font-weight:600;letter-spacing:1px;padding:2px 7px;border-radius:4px;background:rgba(255,255,255,.05);color:var(--grey)}
-.mini-sb-chip.live-a{background:rgba(240,180,41,.15);color:var(--team-a)}
-.mini-sb-chip.live-b{background:rgba(74,158,255,.15);color:var(--team-b)}
-
-/* ── COUNTDOWN BAR ── */
-.countdown-bar{position:fixed;bottom:0;left:0;right:0;z-index:990;background:rgba(11,26,13,.97);border-top:2px solid var(--gold);padding:8px 24px;display:flex;align-items:center;justify-content:center;gap:6px}
-.cd-label{font-family:var(--font-h);font-size:.65rem;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:var(--grey);margin-right:4px}
-.cd-unit{display:flex;flex-direction:column;align-items:center;min-width:38px}
-.cd-num{font-family:var(--font-d);font-size:1.4rem;color:var(--gold);line-height:1}
-.cd-sub{font-family:var(--font-h);font-size:.5rem;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:var(--grey)}
-.cd-sep{font-family:var(--font-d);font-size:1.2rem;color:var(--gold);opacity:.4;align-self:flex-start;padding-top:2px}
-.cd-live{font-family:var(--font-d);font-size:1.1rem;letter-spacing:2px;color:var(--gold)}
-body{padding-bottom:52px}
-@media(max-width:600px){.mini-sb-days{display:none}.cd-num{font-size:1.1rem}.cd-label{display:none}}
-
-.music-modal{position:fixed;inset:0;background:rgba(0,0,0,.85);display:flex;align-items:center;justify-content:center;z-index:99999;backdrop-filter:blur(6px)}
-.music-modal.hidden{display:none}
-.music-modal-card{background:#132415;border:2px solid var(--gold);border-radius:var(--rl);padding:40px 36px;max-width:440px;text-align:center;box-shadow:0 24px 64px rgba(0,0,0,.6)}
-.music-modal-icon{font-size:3rem;margin-bottom:16px}
-.music-modal-title{font-family:var(--font-d);font-size:1.6rem;letter-spacing:2px;color:var(--gold);margin-bottom:12px}
-.music-modal-body{font-size:.95rem;color:#e6dcc4;line-height:1.7;margin-bottom:28px}
-.music-modal-body strong{color:var(--gold)}
-.music-yes{width:100%;padding:14px 20px;font-family:var(--font-d);font-size:1.3rem;letter-spacing:2px;background:var(--gold);color:#0b1a0d;border:none;border-radius:var(--r);cursor:pointer;transition:var(--tr);margin-bottom:10px}
-.music-yes:hover{background:var(--gold-light)}
-.music-no{background:none;border:none;color:#8a9b8d;font-family:var(--font-h);font-size:.75rem;letter-spacing:1px;cursor:pointer;text-transform:uppercase}
-.music-no:hover{color:#efe7d3}
-
-/* Scorecard page body override */
-#page-scorecard { background: var(--canvas); color: var(--ink); min-height: 100vh; }
-#page-scorecard .page-content { max-width: 1200px; margin: 0 auto; padding: 0 24px 64px; }
-#page-scorecard .section-header { padding: 48px 0 24px; border-bottom: 1px solid color-mix(in srgb, var(--gold) 22%, transparent); margin-bottom: 32px; }
-#page-scorecard .section-label { font-family: var(--font-h); font-size: .72rem; font-weight: 600; letter-spacing: 3px; text-transform: uppercase; color: var(--gold); margin-bottom: 6px; }
-#page-scorecard .section-title { font-family: var(--font-d); font-size: clamp(2.4rem,5vw,3.8rem); line-height: 1; letter-spacing: 1px; }
+.draft-hero .eyebrow {
+  font-family: var(--mono, 'Geist Mono', monospace);
+  font-size: .72rem;
+  font-weight: 600;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-bottom: 18px;
+}
+.draft-hero h1 {
+  font-family: var(--display, 'Cormorant Garamond', Georgia, serif);
+  font-size: clamp(2.6rem, 6vw, 4.4rem);
+  font-weight: 600;
+  color: var(--ink);
+  line-height: 1.1;
+  margin-bottom: 20px;
+}
+.draft-hero h1 em {
+  font-style: italic;
+  color: var(--accent-2, #b08d4f);
+}
+.draft-hero .standfirst {
+  font-family: var(--body, 'Geist', sans-serif);
+  font-size: 1.1rem;
+  color: var(--ink-mute);
+  max-width: 560px;
+  margin: 0 auto 40px;
+  line-height: 1.65;
+}
+.draft-badge {
+  display: inline-block;
+  font-family: var(--mono, 'Geist Mono', monospace);
+  font-size: .68rem;
+  font-weight: 600;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent-2, #b08d4f) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-2, #b08d4f) 40%, transparent);
+  color: var(--accent-2, #b08d4f);
+  margin-bottom: 40px;
+}
+.draft-rule {
+  border: none;
+  border-top: 1px solid var(--rule);
+  margin: 48px auto;
+  max-width: 720px;
+}
+.draft-format {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 24px 64px;
+}
+.draft-format h2 {
+  font-family: var(--display, 'Cormorant Garamond', Georgia, serif);
+  font-size: 1.9rem;
+  color: var(--ink);
+  margin-bottom: 16px;
+}
+.draft-format p {
+  font-family: var(--body, 'Geist', sans-serif);
+  font-size: .95rem;
+  color: var(--ink-mute);
+  line-height: 1.7;
+  margin-bottom: 14px;
+}
+.draft-steps {
+  list-style: none;
+  padding: 0;
+  margin: 24px 0 32px;
+  counter-reset: step;
+}
+.draft-steps li {
+  counter-increment: step;
+  display: flex;
+  gap: 18px;
+  align-items: flex-start;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--rule);
+}
+.draft-steps li:last-child {
+  border-bottom: none;
+}
+.draft-steps li::before {
+  content: counter(step, decimal-leading-zero);
+  font-family: var(--mono, 'Geist Mono', monospace);
+  font-size: .75rem;
+  font-weight: 600;
+  color: var(--accent-2, #b08d4f);
+  min-width: 28px;
+  padding-top: 2px;
+}
+.draft-steps li span {
+  font-family: var(--body, 'Geist', sans-serif);
+  font-size: .95rem;
+  color: var(--ink);
+  line-height: 1.6;
+}
+.draft-steps li span strong {
+  display: block;
+  margin-bottom: 2px;
+}
+.draft-steps li span em {
+  font-style: normal;
+  color: var(--ink-mute);
+  font-size: .88rem;
+}
+.live-cta-block {
+  text-align: center;
+  padding: 40px 24px 64px;
+  max-width: 560px;
+  margin: 0 auto;
+}
+.live-cta-block p {
+  font-family: var(--body, 'Geist', sans-serif);
+  font-size: .9rem;
+  color: var(--ink-mute);
+  margin-bottom: 20px;
+  line-height: 1.6;
+}
+.live-cta-btn {
+  display: inline-block;
+  font-family: var(--mono, 'Geist Mono', monospace);
+  font-size: .75rem;
+  font-weight: 600;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  padding: 12px 28px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent-2, #b08d4f) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-2, #b08d4f) 35%, transparent);
+  color: var(--ink-mute);
+  text-decoration: none;
+  cursor: default;
+  opacity: .65;
+}
 </style>
 </head>
 <body>
@@ -265,233 +166,144 @@ body{padding-bottom:52px}
 </div>
 <audio id="bg-audio" src="TheSong.mp3" loop preload="none" style="display:none"></audio>
 
-<!-- Username Picker Modal -->
-<div id="username-modal" class="username-modal hidden">
-  <div class="username-modal-card">
-    <div class="username-modal-title">THE WONGA CUP</div>
-    <div class="username-modal-desc">Enter your name to start scoring</div>
-    <input type="text" id="username-input" class="username-input" placeholder="Your name" maxlength="30" autofocus>
-    <button class="username-btn" onclick="confirmUsername()">Enter Tournament</button>
-    <div class="username-modal-desc" style="font-size:.75rem;margin-top:16px;color:var(--ink-mute)">Your scores will sync live across all devices</div>
-  </div>
-</div>
-
-<!-- Username Badge & Offline Alert -->
-<div id="username-badge" class="username-badge" style="display:none"></div>
-<div id="offline-banner" class="offline-banner" style="display:none">⚠ Offline — Using Local Storage</div>
-<div id="save-toast" class="save-toast"></div>
-
-<!-- ══════════════════════════════════════
-     NEW MASTHEAD
-══════════════════════════════════════ -->
-<header class="masthead masthead--scrolled">
+<!-- ═══════════════════════════════════════════════════════════════════════
+     MASTHEAD
+═══════════════════════════════════════════════════════════════════════ -->
+<header class="masthead masthead--scrolled" id="masthead">
   <div class="masthead-inner">
     <div class="masthead-left">
-      <a href="index.html" class="back-link">← Tournament Info</a>
+      <span>A.G.E.</span>
+      <span class="moto">·</span>
+      <span class="moto">2026</span>
     </div>
-    <a href="scorecard.html" class="masthead-center">A.G.E IV: The Wonga Cup</a>
-    <div class="masthead-right"></div>
+    <a href="index.html" class="masthead-center">A.G.E IV: The Wonga Cup</a>
+    <div class="masthead-right">
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="golfers.html">Golfers</a>
+        <a href="records.html">Records</a>
+        <a href="practical.html">Info</a>
+        <a href="scorecard.html" class="nav-cta">Scorecard ↗</a>
+      </nav>
+      <button class="hamburger" id="hamburger" aria-label="Open menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
   </div>
 </header>
 
-<!-- Editorial page header (light, matches index.html brand) -->
-<div class="sc-page-header">
-  <div class="sc-page-header-inner">
-    <div class="sc-page-eyebrow">Live Scoring · A.G.E IV · 2026</div>
-    <div class="sc-page-title">The Wonga Cup</div>
-    <div class="sc-page-sub">Yarrawonga &amp; Mulwala G.C. · 7–9 August</div>
+<!-- Mobile nav -->
+<nav class="mobile-menu" id="mobile-menu" aria-hidden="true">
+  <a href="index.html" class="mm-link" onclick="closeMenu()">Home</a>
+  <a href="golfers.html" class="mm-link" onclick="closeMenu()">Golfers</a>
+  <a href="records.html" class="mm-link" onclick="closeMenu()">Records</a>
+  <a href="practical.html" class="mm-link" onclick="closeMenu()">Info</a>
+  <a href="scorecard.html" class="mm-link mm-cta">Live Scorecard ↗</a>
+</nav>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     DRAFT PLACEHOLDER
+═══════════════════════════════════════════════════════════════════════ -->
+<section class="draft-hero">
+  <div class="shell">
+    <div class="eyebrow">A.G.E IV · Yarrawonga &amp; Mulwala G.C. · 7–9 August 2026</div>
+    <h1>Teams decided by<br><em>Captain's Draft.</em></h1>
+    <p class="standfirst">
+      The field is split on the morning of Day 1 via peer vote and snake draft.
+      Once the captains are picked and the teams are set, the live scorecard goes live.
+    </p>
+    <div class="draft-badge">Live Scorecard · Available from Draft Day</div>
   </div>
+</section>
+
+<hr class="draft-rule">
+
+<div class="draft-format">
+  <h2>How the draft works</h2>
+  <p>
+    Instead of preset teams, captains are chosen by the field on the Friday morning — whoever the group votes for leads a side. The two captains then alternate picks in a snake draft until all 14 players are allocated.
+  </p>
+  <ol class="draft-steps">
+    <li>
+      <span>
+        <strong>Peer vote for captains</strong>
+        <em>Friday morning, before tee-off — players nominate and vote for two captains.</em>
+      </span>
+    </li>
+    <li>
+      <span>
+        <strong>Snake draft</strong>
+        <em>Captains alternate picks (1-2-2-2-…-1) until all 14 players are assigned to a team.</em>
+      </span>
+    </li>
+    <li>
+      <span>
+        <strong>Team names chosen by captains</strong>
+        <em>Each captain names their side — bragging rights on the line from the first pick.</em>
+      </span>
+    </li>
+    <li>
+      <span>
+        <strong>Live scorecard goes live</strong>
+        <em>Once teams are confirmed, this page will link through to the full scoring tool.</em>
+      </span>
+    </li>
+  </ol>
+  <p>
+    Three days of competition follow: Friday match play, Saturday scramble, Sunday Stableford.
+    Points accumulate across all three rounds — the team with the most points lifts the cup.
+  </p>
 </div>
 
-<!-- Mini Scoreboard -->
-<div class="mini-sb" id="mini-sb">
-  <div class="mini-sb-team mini-sb-a">
-    <span class="mini-sb-name" id="mini-name-a">Team Beer</span>
-    <span class="mini-sb-score" id="mini-score-a">0</span>
-  </div>
-  <span class="mini-sb-vs">vs</span>
-  <div class="mini-sb-team mini-sb-b">
-    <span class="mini-sb-score" id="mini-score-b">0</span>
-    <span class="mini-sb-name" id="mini-name-b">Team Golf</span>
-  </div>
-  <div class="mini-sb-days" id="mini-sb-days"></div>
+<div class="live-cta-block">
+  <p>The live scoring tool will be available once the draft is complete on Friday morning.</p>
+  <a href="scorecard-live.html" class="live-cta-btn" aria-disabled="true">Live Scorecard — Coming Soon</a>
 </div>
 
-<!-- ══════════════════════════════════════
-     LIVE SCORECARD
-══════════════════════════════════════ -->
-<div id="page-scorecard">
-
-  <!-- Pinned scoreboard -->
-  <div class="scoreboard-pin">
-    <div class="scoreboard-inner">
-      <div class="team-a">
-        <div class="sb-team-name" id="sb-team-name-a">Team Beer</div>
-        <div class="sb-total" id="sb-total-a">0</div>
-        <div class="sb-day-chips" id="sb-chips-a">
-          <span class="sb-chip">D1: 0</span>
-          <span class="sb-chip">D2: 0</span>
-          <span class="sb-chip">D3: 0</span>
-        </div>
+<!-- ═══════════════════════════════════════════════════════════════════════
+     FOOTER
+═══════════════════════════════════════════════════════════════════════ -->
+<footer class="foot">
+  <div class="shell">
+    <div class="row1">
+      <div class="col">
+        <h5>The Tournament</h5>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="golfers.html">Golfers</a></li>
+          <li><a href="records.html">History &amp; Records</a></li>
+          <li><a href="practical.html">Practical Info</a></li>
+          <li><a href="scorecard.html">Live Scorecard ↗</a></li>
+        </ul>
       </div>
-      <div class="sb-vs">VS</div>
-      <div class="team-b">
-        <div class="sb-team-name" id="sb-team-name-b">Team Golf</div>
-        <div class="sb-total" id="sb-total-b">0</div>
-        <div class="sb-day-chips" id="sb-chips-b">
-          <span class="sb-chip">D1: 0</span>
-          <span class="sb-chip">D2: 0</span>
-          <span class="sb-chip">D3: 0</span>
-        </div>
+      <div class="col">
+        <h5>Host Club</h5>
+        <ul>
+          <li>Yarrawonga &amp; Mulwala G.C.</li>
+          <li>Park &amp; Murray Streets</li>
+          <li>Mulwala NSW 2647</li>
+        </ul>
+      </div>
+      <div class="col">
+        <h5>Accommodation</h5>
+        <ul>
+          <li>45 Anchorage Way 2</li>
+          <li>Yarrawonga VIC 3730</li>
+          <li>Check-in from 2:00 PM, Friday</li>
+          <li>Checkout before 10:00 AM, Sunday</li>
+        </ul>
       </div>
     </div>
-    <div id="win-banner" style="display:none"></div>
+    <div class="colophon">
+      <div>The Wonga Cup · Fourth Edition · 2026</div>
+      <div>Set in Cormorant &amp; Geist</div>
+    </div>
   </div>
+</footer>
 
-  <!-- Live sync bar -->
-  <div class="sync-bar">
-    <span class="sync-label"><span class="live-dot"></span>Live Scores</span>
-    <button class="refresh-btn" onclick="loadFromSupabase().then(() => refreshAllDays())">🔄 Refresh</button>
-    <span class="sync-spacer"></span>
-  </div>
-
-  <!-- Sub-tabs -->
-  <div class="sc-tabs">
-    <button class="sc-tab active" data-tab="teams">Teams</button>
-    <button class="sc-tab" data-tab="day1">Day 1</button>
-    <button class="sc-tab" data-tab="day2">Day 2</button>
-    <button class="sc-tab" data-tab="day3">Day 3</button>
-  </div>
-
-  <!-- ── TEAMS PANEL ── -->
-  <div class="page-content">
-    <div class="sc-panel active" id="sc-teams">
-      <div class="section-header" style="padding-top:28px">
-        <div class="section-label">Setup</div>
-        <div class="section-title">Team Names</div>
-      </div>
-      <div style="display:flex;gap:12px;flex-wrap:wrap;margin-bottom:24px;align-items:flex-end">
-        <div style="flex:1;min-width:140px">
-          <label style="display:block;font-family:var(--font-h);font-size:.65rem;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:var(--team-a);margin-bottom:6px">Team A Name</label>
-          <input id="tn-input-a" type="text" value="Team Beer" maxlength="24"
-            style="width:100%;background:var(--canvas-2);border:1px solid color-mix(in srgb,var(--team-a) 40%,transparent);border-radius:var(--r);padding:10px 14px;color:var(--ink);font-size:.95rem;font-family:var(--font-h)">
-        </div>
-        <div style="flex:1;min-width:140px">
-          <label style="display:block;font-family:var(--font-h);font-size:.65rem;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:var(--team-b);margin-bottom:6px">Team B Name</label>
-          <input id="tn-input-b" type="text" value="Team Golf" maxlength="24"
-            style="width:100%;background:var(--canvas-2);border:1px solid color-mix(in srgb,var(--team-b) 40%,transparent);border-radius:var(--r);padding:10px 14px;color:var(--ink);font-size:.95rem;font-family:var(--font-h)">
-        </div>
-        <button onclick="saveTeamNames()" style="background:var(--gold);color:#0b1a0d;font-family:var(--font-h);font-weight:700;font-size:.78rem;letter-spacing:1.5px;text-transform:uppercase;border:none;border-radius:var(--r);padding:10px 20px;cursor:pointer;white-space:nowrap">Save Names</button>
-      </div>
-
-      <div class="section-header" style="padding-top:4px">
-        <div class="section-label">Setup</div>
-        <div class="section-title">Team Assignment</div>
-      </div>
-      <div class="info-box">Adjust team assignments as needed. Click "→ B" or "← A" to move a player.</div>
-      <div class="team-setup-grid">
-        <div class="team-col team-a-col">
-          <div class="team-col-h" id="team-col-h-a">Team Beer</div>
-          <div id="team-a-list"></div>
-        </div>
-        <div class="team-col team-b-col">
-          <div class="team-col-h" id="team-col-h-b">Team Golf</div>
-          <div id="team-b-list"></div>
-        </div>
-      </div>
-      <button onclick="resetTeams()" style="padding:10px 22px;font-family:var(--font-h);font-size:.8rem;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;background:transparent;border:1px solid var(--rule-strong);color:var(--ink-mute);border-radius:var(--r);cursor:pointer">Reset to Default</button>
-    </div>
-
-    <!-- ── DAY 1 PANEL ── -->
-    <div class="sc-panel" id="sc-day1">
-      <div class="section-header" style="padding-top:28px">
-        <div class="section-label">Friday 7 August · Murray Course · 12:00pm</div>
-        <div class="section-title">Match Play Best Ball</div>
-      </div>
-      <div class="info-box">10 players play Friday (Cayden Woods &amp; Ben Lepore join Saturday). Assign Friday players to matches below. For each hole, click <strong style="color:var(--team-a)">A</strong> (Team A wins hole), <strong style="color:var(--ink)">H</strong> (Halved), or <strong style="color:var(--team-b)">B</strong> (Team B wins hole). <strong>Scoring:</strong> 1pt per hole won, 0.5pt halved, +2 bonus to match winner.</div>
-      <div id="day1-matches"></div>
-    </div>
-
-    <!-- ── DAY 2 PANEL ── -->
-    <div class="sc-panel" id="sc-day2">
-      <div class="section-header" style="padding-top:28px">
-        <div class="section-label">Saturday 8 August · Black Bull · 12:00pm</div>
-        <div class="section-title">Team Scramble</div>
-      </div>
-      <div class="info-box">Each team splits into a <strong>group of 4</strong> and a <strong>group of 2</strong>. Enter the net score vs par for each group (e.g. <strong>-2</strong> for two under par, <strong>+3</strong> for three over). Points: Par = 5pts, each stroke under = +1pt extra, each over = −1pt (min 0).</div>
-      <div class="scramble-grid">
-        <div class="scramble-team-card scramble-team-a">
-          <div class="scramble-team-title" id="scramble-title-a">Team Beer</div>
-          <div class="sig">
-            <label>Group of 4 — Net Score vs Par</label>
-            <div class="sig-row">
-              <input type="number" id="a4-score" placeholder="0" oninput="updateDay2()">
-              <div class="pts-badge" id="a4-pts">— pts</div>
-            </div>
-          </div>
-          <div class="sig">
-            <label>Group of 2 — Net Score vs Par</label>
-            <div class="sig-row">
-              <input type="number" id="a2-score" placeholder="0" oninput="updateDay2()">
-              <div class="pts-badge" id="a2-pts">— pts</div>
-            </div>
-          </div>
-          <div class="day-total-row"><span class="lbl">Team A Day 2 Total</span><span class="val" id="a-day2-total">0 pts</span></div>
-        </div>
-        <div class="scramble-team-card scramble-team-b">
-          <div class="scramble-team-title" id="scramble-title-b">Team Golf</div>
-          <div class="sig">
-            <label>Group of 4 — Net Score vs Par</label>
-            <div class="sig-row">
-              <input type="number" id="b4-score" placeholder="0" oninput="updateDay2()">
-              <div class="pts-badge" id="b4-pts">— pts</div>
-            </div>
-          </div>
-          <div class="sig">
-            <label>Group of 2 — Net Score vs Par</label>
-            <div class="sig-row">
-              <input type="number" id="b2-score" placeholder="0" oninput="updateDay2()">
-              <div class="pts-badge" id="b2-pts">— pts</div>
-            </div>
-          </div>
-          <div class="day-total-row"><span class="lbl">Team B Day 2 Total</span><span class="val" id="b-day2-total">0 pts</span></div>
-        </div>
-      </div>
-    </div>
-
-    <!-- ── DAY 3 PANEL ── -->
-    <div class="sc-panel" id="sc-day3">
-      <div class="section-header" style="padding-top:28px">
-        <div class="section-label">Sunday 9 August · Lake Course · 10:00am</div>
-        <div class="section-title">Individual Stableford</div>
-      </div>
-      <div class="info-box">Enter each player's <strong>net Stableford score</strong>. Players are ranked automatically — highest score = 1st. Points by finishing position: <strong>1st=14, 2nd=12, 3rd=11, 4th=10, 5th=9, 6th=8, 7th=7, 8th=6, 9th=5, 10th=4, 11th=3, 12th=2, 13th=1, 14th=0</strong>. Tied players share averaged points. Each player's points go to their team total.</div>
-      <div class="sf-table-wrap">
-        <table class="sf-table">
-          <thead>
-            <tr>
-              <th style="width:44px">Pos</th>
-              <th>Player</th>
-              <th>Team</th>
-              <th>HCP</th>
-              <th>Net Stableford</th>
-              <th style="text-align:right">Pts</th>
-            </tr>
-          </thead>
-          <tbody id="sf-tbody"></tbody>
-        </table>
-      </div>
-    </div>
-
-  </div><!-- /page-content -->
-</div><!-- /page-scorecard -->
-
-<!-- Countdown Bar -->
-<div class="countdown-bar" id="countdown-bar"></div>
-
-<!-- ══════════════════════════════════════
+<!-- ═══════════════════════════════════════════════════════════════════════
      THEME SWITCHER
-══════════════════════════════════════ -->
+═══════════════════════════════════════════════════════════════════════ -->
 <div class="theme-switcher" id="theme-switcher" hidden>
   <div class="tlabel">Coat of Paint</div>
   <div class="row" role="radiogroup" aria-label="theme">
@@ -508,899 +320,36 @@ body{padding-bottom:52px}
 
 <script src="theme.js"></script>
 <script>
-/* ─────────────────────────────────────
-   SUPABASE CONFIG — REPLACE WITH YOUR VALUES
-───────────────────────────────────── */
-const SUPABASE_CONFIG = {
-  apiUrl: 'https://wtyyarvyscbrrkawjcvo.supabase.co',
-  apiKey: 'sb_publishable_T1z1rYbZ7yMoDdBXZMrjKw_R3aTxsrx',
-  tournamentId: 'wonga-cup-2026',
-  sessionKey: 'wonga-cup-2026'
-};
-const LAST_SYNC_KEY = 'wongaCup2026_lastSync';
-
-let currentUsername = null;
-let isOffline = false;
-let autoPollingInterval = null;
-let lastSaveTime = 0;
-
-/* ─────────────────────────────────────
-   DATA
-───────────────────────────────────── */
-const PLAYERS = [
-  { id:0,  name:'Brendan Cunningham', short:'B. Cunningham', hcp:'7.0',  seed:1,  friday:true  },
-  { id:1,  name:'Gary King',          short:'G. King',       hcp:'10.0', seed:2,  friday:true  },
-  { id:2,  name:'Matthew Smith',      short:'M. Smith',      hcp:'15.8', seed:3,  friday:true  },
-  { id:3,  name:'James McIntyre',     short:'J. McIntyre',   hcp:'17.7', seed:4,  friday:true  },
-  { id:4,  name:'Cayden Woods',       short:'C. Woods',      hcp:'24.0', seed:5,  friday:false },
-  { id:5,  name:'Scott Rumbelow',     short:'S. Rumbelow',   hcp:'25.0', seed:6,  friday:true  },
-  { id:6,  name:'Matthew Freestun',   short:'M. Freestun',   hcp:'26.7', seed:7,  friday:true  },
-  { id:7,  name:'Nathan Freestun',    short:'N. Freestun',   hcp:'27.0', seed:8,  friday:true  },
-  { id:8,  name:'Steve Koenig',       short:'S. Koenig',     hcp:'31.0', seed:9,  friday:true  },
-  { id:9,  name:'Jimmy Hepburn',      short:'J. Hepburn',    hcp:'TBC',  seed:10, friday:true  },
-  { id:10, name:'Robert Hughes',      short:'R. Hughes',     hcp:'38.0', seed:11, friday:true  },
-  { id:11, name:'Ben Lepore',         short:'B. Lepore',     hcp:'44.0', seed:12, friday:false },
-  { id:12, name:'TBC',               short:'TBC',           hcp:'TBC',  seed:13, friday:true  },
-  { id:13, name:'TBC',               short:'TBC',           hcp:'TBC',  seed:14, friday:true  }
-];
-
-// Default: seeds 1,3,5,8,10,12,13 = A;  seeds 2,4,6,7,9,11,14 = B
-const DEFAULT_A = new Set([0,2,4,7,9,11,12]);
-const DEFAULT_B = new Set([1,3,5,6,8,10,13]);
-
-/* ─────────────────────────────────────
-   STATE
-───────────────────────────────────── */
-const state = {
-  teamNameA: 'Team Beer',
-  teamNameB: 'Team Golf',
-  teamA: new Set(DEFAULT_A),
-  teamB: new Set(DEFAULT_B),
-  day1: {
-    matches: [
-      { type:'singles', pA:[null],      pB:[null],      winner:null, margin:null },
-      { type:'doubles', pA:[null,null], pB:[null,null], winner:null, margin:null },
-      { type:'doubles', pA:[null,null], pB:[null,null], winner:null, margin:null }
-    ]
-  },
-  day2: { a4:null, a2:null, b4:null, b2:null },
-  day3: {}  // id -> stableford score string
-};
-
-/* ─────────────────────────────────────
-   PERSISTENCE
-───────────────────────────────────── */
-function saveState() {
-  try {
-    const s = {
-      teamNameA: state.teamNameA,
-      teamNameB: state.teamNameB,
-      teamA: [...state.teamA],
-      teamB: [...state.teamB],
-      day1:  JSON.parse(JSON.stringify(state.day1)),
-      day2:  state.day2,
-      day3:  state.day3
-    };
-    localStorage.setItem('wongaCup2026', JSON.stringify(s));
-  } catch(e) {}
-  lastSaveTime = Date.now();
-}
-
-function loadState() {
-  try {
-    const raw = localStorage.getItem('wongaCup2026');
-    if (!raw) return;
-    const s = JSON.parse(raw);
-    if (s.teamNameA) state.teamNameA = s.teamNameA;
-    if (s.teamNameB) state.teamNameB = s.teamNameB;
-    if (s.teamA) state.teamA = new Set(s.teamA);
-    if (s.teamB) state.teamB = new Set(s.teamB);
-    if (s.day1)  state.day1  = s.day1;
-    if (s.day2)  state.day2  = s.day2;
-    if (s.day3)  state.day3  = s.day3;
-  } catch(e) {}
-}
-
-/* ─────────────────────────────────────
-   NAVIGATION
-───────────────────────────────────── */
-document.querySelectorAll('.sc-tab').forEach(btn => {
-  btn.addEventListener('click', () => {
-    document.querySelectorAll('.sc-tab').forEach(x => x.classList.remove('active'));
-    document.querySelectorAll('.sc-panel').forEach(x => x.classList.remove('active'));
-    btn.classList.add('active');
-    document.getElementById('sc-' + btn.dataset.tab).classList.add('active');
-  });
-});
-
-/* ─────────────────────────────────────
-   TEAM SETUP
-───────────────────────────────────── */
-function renderTeams() {
-  const aList = document.getElementById('team-a-list');
-  const bList = document.getElementById('team-b-list');
-  aList.innerHTML = '';
-  bList.innerHTML = '';
-
-  PLAYERS.forEach(p => {
-    const inA = state.teamA.has(p.id);
-    const el = document.createElement('div');
-    el.className = 'team-player-item';
-    el.innerHTML = `
-      <div>
-        <span>${p.name}</span>
-        <small style="display:block">HCP ${p.hcp}${!p.friday ? ' · Sat–Sun' : ''}</small>
-      </div>
-      <button class="move-btn" onclick="movePlayer(${p.id},${inA ? 'true' : 'false'})">
-        ${inA ? '→ B' : '← A'}
-      </button>`;
-    (inA ? aList : bList).appendChild(el);
-  });
-  saveState();
-  updateScoreboard();
-  renderDay1();
-  renderDay3();
-  renderOverviewTeams();
-  renderFieldTeamBadges();
-}
-
-function movePlayer(id, fromA) {
-  if (fromA) { state.teamA.delete(id); state.teamB.add(id); }
-  else        { state.teamB.delete(id); state.teamA.add(id); }
-  saveState();
-  insertUpdate('team_assign', { field_key: 'A', value: JSON.stringify([...state.teamA]) });
-  insertUpdate('team_assign', { field_key: 'B', value: JSON.stringify([...state.teamB]) });
-  renderTeams();
-}
-
-function resetTeams() {
-  state.teamA = new Set(DEFAULT_A);
-  state.teamB = new Set(DEFAULT_B);
-  renderTeams();
-}
-
-function renderOverviewTeams() {
-  const el = document.getElementById('overview-teams');
-  if (!el) return;
-  const nameA = state.teamNameA || 'Team A';
-  const nameB = state.teamNameB || 'Team B';
-  const playersA = PLAYERS.filter(p => state.teamA.has(p.id));
-  const playersB = PLAYERS.filter(p => state.teamB.has(p.id));
-  const makeList = (players) => players.map(p =>
-    `<li style="display:flex;justify-content:space-between;align-items:center;padding:6px 0;border-bottom:1px solid var(--rule)">
-      <span style="color:var(--ink)">${p.name}</span>
-      <span style="font-size:.8rem;color:var(--ink-mute)">HCP ${p.hcp}</span>
-    </li>`
-  ).join('');
-  el.innerHTML = `
-    <div class="section-header" style="padding-top:32px">
-      <div class="section-label">2026</div>
-      <div class="section-title">The Teams</div>
-    </div>
-    <div class="grid-2" style="gap:16px;margin-bottom:32px">
-      <div class="card">
-        <div style="font-family:var(--font-h);font-size:.72rem;font-weight:700;letter-spacing:2px;text-transform:uppercase;color:var(--team-a);margin-bottom:12px">${nameA}</div>
-        <ul style="list-style:none;padding:0;margin:0">${makeList(playersA)}</ul>
-      </div>
-      <div class="card">
-        <div style="font-family:var(--font-h);font-size:.72rem;font-weight:700;letter-spacing:2px;text-transform:uppercase;color:var(--team-b);margin-bottom:12px">${nameB}</div>
-        <ul style="list-style:none;padding:0;margin:0">${makeList(playersB)}</ul>
-      </div>
-    </div>`;
-}
-
-function renderFieldTeamBadges() {
-  PLAYERS.forEach(p => {
-    const card = document.querySelector(`[data-field-pid="${p.id}"]`);
-    if (!card) return;
-    let badge = card.querySelector('.field-team-badge');
-    if (!badge) {
-      badge = document.createElement('span');
-      const body = card.querySelector('.player-card-body');
-      if (body) body.insertBefore(badge, body.firstChild);
-    }
-    const inA = state.teamA.has(p.id);
-    const teamName = inA ? (state.teamNameA || 'Team A') : (state.teamNameB || 'Team B');
-    badge.className = `field-team-badge team-badge ${inA ? 'ta-badge' : 'tb-badge'}`;
-    badge.style.cssText = 'display:inline-block;margin-bottom:10px';
-    badge.textContent = teamName;
-  });
-}
-
-/* ─────────────────────────────────────
-   DAY 1 — MATCH PLAY
-───────────────────────────────────── */
-function fridayPlayers(team) {
-  return PLAYERS.filter(p => p.friday && (team === 'A' ? state.teamA : state.teamB).has(p.id));
-}
-
-function playerOptions(team, matchIdx, slot, currentId) {
-  const pool = fridayPlayers(team);
-  const usedInOthers = new Set();
-  state.day1.matches.forEach((m, mi) => {
-    if (mi === matchIdx) return;
-    (m.pA || []).forEach(x => { if (x !== null) usedInOthers.add(x); });
-    (m.pB || []).forEach(x => { if (x !== null) usedInOthers.add(x); });
-  });
-  // Also used in same match different slots
-  const match = state.day1.matches[matchIdx];
-  const sameTeamArr = team === 'A' ? match.pA : match.pB;
-  const usedSameMatch = new Set(sameTeamArr.filter((x,i) => i !== slot && x !== null));
-
-  let opts = `<option value="">— pick player —</option>`;
-  pool.forEach(p => {
-    const disabled = usedInOthers.has(p.id) || usedSameMatch.has(p.id) ? 'disabled' : '';
-    const sel = p.id === currentId ? 'selected' : '';
-    opts += `<option value="${p.id}" ${disabled} ${sel}>${p.short} (${p.hcp})</option>`;
-  });
-  return opts;
-}
-
-function renderDay1() {
-  const container = document.getElementById('day1-matches');
-  container.innerHTML = '';
-  const titles = ['Match 1 — Singles (1v1)', 'Match 2 — Doubles (2v2)', 'Match 3 — Doubles (2v2)'];
-
-  state.day1.matches.forEach((match, mi) => {
-    const { pA, pB, winner, margin, type } = match;
-    const slots = type === 'singles' ? 1 : 2;
-    const ptsA = winner === 'A' ? 2 : winner === 'AS' ? 1 : 0;
-    const ptsB = winner === 'B' ? 2 : winner === 'AS' ? 1 : 0;
-
-    const card = document.createElement('div');
-    card.className = 'match-card' + (winner === 'A' ? ' win-a' : winner === 'B' ? ' win-b' : winner === 'AS' ? ' win-as' : '');
-
-    // Header
-    const hd = document.createElement('div');
-    hd.className = 'match-header';
-    hd.innerHTML = `
-      <div class="match-title">${titles[mi]}</div>
-      <div class="match-score-display">
-        <span class="msa">${ptsA}</span>
-        <span class="mss">pts</span>
-        <span class="msb">${ptsB}</span>
-      </div>`;
-    card.appendChild(hd);
-
-    // Player assignments
-    const pr = document.createElement('div');
-    pr.className = 'match-players-row';
-    let aHtml = `<div class="player-group"><div class="pg-label pgl-a">${state.teamNameA.toUpperCase()}</div>`;
-    for (let s = 0; s < slots; s++) {
-      aHtml += `<select onchange="setMatchPlayer(${mi},'A',${s},this.value)">${playerOptions('A',mi,s,pA[s])}</select>`;
-    }
-    aHtml += `</div>`;
-    let bHtml = `<div class="player-group pb"><div class="pg-label pgl-b" style="text-align:right">${state.teamNameB.toUpperCase()}</div>`;
-    for (let s = 0; s < slots; s++) {
-      bHtml += `<select onchange="setMatchPlayer(${mi},'B',${s},this.value)">${playerOptions('B',mi,s,pB[s])}</select>`;
-    }
-    bHtml += `</div>`;
-    pr.innerHTML = aHtml + `<div class="vs-div">VS</div>` + bHtml;
-    card.appendChild(pr);
-
-    // Result entry — simple winner + margin
-    const re = document.createElement('div');
-    re.className = 'running-score-row';
-    re.style = 'display:flex;align-items:center;gap:12px;flex-wrap:wrap;padding:14px 22px';
-    re.innerHTML = `
-      <span style="font-family:var(--font-h);font-size:.72rem;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:var(--ink-mute)">Result:</span>
-      <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
-        <input type="radio" name="m${mi}-winner" value="A" ${winner==='A'?'checked':''} onchange="setMatchResult(${mi},this.value)">
-        <span style="color:var(--team-a);font-family:var(--font-h);font-weight:600">${state.teamNameA}</span>
-      </label>
-      <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
-        <input type="radio" name="m${mi}-winner" value="AS" ${winner==='AS'?'checked':''} onchange="setMatchResult(${mi},this.value)">
-        <span style="color:var(--ink-mute);font-family:var(--font-h);font-weight:600">All Square</span>
-      </label>
-      <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
-        <input type="radio" name="m${mi}-winner" value="B" ${winner==='B'?'checked':''} onchange="setMatchResult(${mi},this.value)">
-        <span style="color:var(--team-b);font-family:var(--font-h);font-weight:600">${state.teamNameB}</span>
-      </label>
-      ${winner && winner !== 'AS' ? `
-      <span style="font-family:var(--font-h);font-size:.72rem;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:var(--ink-mute);margin-left:8px">By:</span>
-      <input type="number" min="1" max="10" value="${margin||''}" placeholder="holes up"
-        style="width:90px;padding:5px 8px;background:var(--canvas-2);border:1px solid var(--rule-strong);border-radius:var(--r);color:var(--ink);font-family:var(--font-b);font-size:.9rem"
-        oninput="setMatchMargin(${mi},this.value)">
-      <span style="color:var(--ink-mute);font-size:.85rem">up</span>` : ''}
-    `;
-    card.appendChild(re);
-    container.appendChild(card);
-  });
-}
-
-function fmt(n) {
-  if (n === Math.floor(n)) return n.toString();
-  return n.toFixed(1);
-}
-
-function setMatchPlayer(matchIdx, team, slot, val) {
-  const id = val === '' ? null : parseInt(val);
-  if (team === 'A') state.day1.matches[matchIdx].pA[slot] = id;
-  else              state.day1.matches[matchIdx].pB[slot] = id;
-  saveState();
-  renderDay1();
-  updateScoreboard();
-}
-
-function setMatchResult(matchIdx, winner) {
-  requireUsername(() => {
-    state.day1.matches[matchIdx].winner = winner;
-    if (winner === 'AS') state.day1.matches[matchIdx].margin = null;
-    saveState();
-    insertUpdate('day1_match', { match_idx: matchIdx, value: winner });
-    renderDay1();
-    updateScoreboard();
-  });
-}
-
-function setMatchMargin(matchIdx, val) {
-  state.day1.matches[matchIdx].margin = val === '' ? null : parseInt(val);
-  saveState();
-  insertUpdate('day1_margin', { match_idx: matchIdx, value: val === '' ? null : parseInt(val) });
-}
-
-/* ─────────────────────────────────────
-   DAY 2 — SCRAMBLE
-───────────────────────────────────── */
-function scramblePoints(val) {
-  if (val === '' || val === null || val === undefined) return null;
-  const n = parseInt(val);
-  if (isNaN(n)) return null;
-  return Math.max(0, 5 - n);
-}
-
-function updateDay2() {
-  requireUsername(() => {
-    _doUpdateDay2();
-    ['a4','a2','b4','b2'].forEach(id => {
-      insertUpdate('day2_score', { field_key: id, value: state.day2[id] });
-    });
-  });
-}
-function _doUpdateDay2() {
-  const ids = ['a4','a2','b4','b2'];
-  ids.forEach(id => {
-    const inp = document.getElementById(id + '-score');
-    const pts = scramblePoints(inp.value);
-    const badge = document.getElementById(id + '-pts');
-    state.day2[id] = inp.value;
-    if (pts !== null) {
-      badge.textContent = pts + ' pts';
-      badge.classList.add('live');
-    } else {
-      badge.textContent = '— pts';
-      badge.classList.remove('live');
-    }
-  });
-
-  const aTotal = (scramblePoints(state.day2.a4)||0) + (scramblePoints(state.day2.a2)||0);
-  const bTotal = (scramblePoints(state.day2.b4)||0) + (scramblePoints(state.day2.b2)||0);
-  document.getElementById('a-day2-total').textContent = aTotal + ' pts';
-  document.getElementById('b-day2-total').textContent = bTotal + ' pts';
-
-  const cardA = document.querySelector('.scramble-team-a');
-  const cardB = document.querySelector('.scramble-team-b');
-  if (cardA && cardB) {
-    cardA.classList.toggle('leading', aTotal > 0 && aTotal >= bTotal);
-    cardB.classList.toggle('leading', bTotal > 0 && bTotal > aTotal);
-  }
-
-  saveState();
-  updateScoreboard();
-}
-
-function restoreDay2() {
-  ['a4','a2','b4','b2'].forEach(id => {
-    const el = document.getElementById(id + '-score');
-    if (el && state.day2[id] !== null && state.day2[id] !== undefined) {
-      el.value = state.day2[id];
-    }
-  });
-  _doUpdateDay2();
-}
-
-/* ─────────────────────────────────────
-   DAY 3 — STABLEFORD
-───────────────────────────────────── */
-const POS_PTS = [14,12,11,10,9,8,7,6,5,4,3,2,1,0];
-
-function computeDay3() {
-  const entries = PLAYERS.map(p => ({
-    id:    p.id,
-    name:  p.name,
-    hcp:   p.hcp,
-    team:  state.teamA.has(p.id) ? 'A' : 'B',
-    score: state.day3[p.id] !== undefined && state.day3[p.id] !== '' ? parseInt(state.day3[p.id]) : null
-  }));
-
-  // Sort by score desc (nulls last)
-  const sorted = [...entries].sort((a,b) => {
-    if (a.score === null && b.score === null) return 0;
-    if (a.score === null) return 1;
-    if (b.score === null) return -1;
-    return b.score - a.score;
-  });
-
-  // Assign positions with tie handling
-  let i = 0;
-  while (i < sorted.length) {
-    if (sorted[i].score === null) { sorted[i].pos = null; sorted[i].pts = 0; i++; continue; }
-    let j = i;
-    while (j < sorted.length && sorted[j].score === sorted[i].score) j++;
-    let totalPts = 0;
-    for (let k = i; k < j; k++) totalPts += (POS_PTS[k] || 0);
-    const avgPts = totalPts / (j - i);
-    for (let k = i; k < j; k++) { sorted[k].pos = i + 1; sorted[k].pts = avgPts; }
-    i = j;
-  }
-
-  return { sorted, entries };
-}
-
-function renderDay3() {
-  const tbody = document.getElementById('sf-tbody');
-  if (!tbody) return;
-  const { sorted } = computeDay3();
-  tbody.innerHTML = '';
-  const maxPts = POS_PTS[0];
-  const topScore = sorted[0]?.score;
-  sorted.forEach(p => {
-    const row = document.createElement('tr');
-    const isTop = p.score !== null && p.score === topScore;
-    row.className = (p.team === 'A' ? 'row-a' : 'row-b') + (isTop ? ' top-scorer' : '');
-    const intensity = p.pts > 0 ? 0.05 + (p.pts / maxPts) * 0.28 : 0.03;
-    const rgb = p.team === 'A' ? '240,180,41' : '74,158,255';
-    row.style.background = `rgba(${rgb},${intensity.toFixed(3)})`;
-    const posClass = p.pos === 1 ? 'pos-1' : p.pos === 2 ? 'pos-2' : p.pos === 3 ? 'pos-3' : '';
-    const posText  = p.pos ? (p.pos === 1 ? '🥇' : p.pos === 2 ? '🥈' : p.pos === 3 ? '🥉' : p.pos) : '—';
-    const ptsText  = p.score !== null ? (p.pts % 1 === 0 ? p.pts : p.pts.toFixed(1)) : '—';
-    row.innerHTML = `
-      <td class="pos-cell ${posClass}">${posText}</td>
-      <td style="color:var(--ink)">${p.name}</td>
-      <td><span class="${p.team === 'A' ? 'ta-badge' : 'tb-badge'} team-badge">Team ${p.team}</span></td>
-      <td class="grey" style="font-size:.84rem">${p.hcp}</td>
-      <td><input type="number" class="sf-in" placeholder="—" value="${state.day3[p.id]||''}" data-pid="${p.id}" oninput="setStableford(${p.id},this.value)"></td>
-      <td class="pts-cell">${ptsText}</td>`;
-    tbody.appendChild(row);
-  });
-  updateScoreboard();
-}
-
-function setStableford(pid, val) {
-  requireUsername(() => {
-    state.day3[pid] = val;
-    saveState();
-    insertUpdate('day3_stableford', { player_id: pid, value: val });
-    const { sorted } = computeDay3();
-    const player = sorted.find(p => p.id === pid);
-    if (player) {
-      const row = document.querySelector(`[data-pid="${pid}"]`)?.closest('tr');
-      if (row) {
-        const ptsCell = row.querySelector('.pts-cell');
-        if (ptsCell) ptsCell.textContent = player.pts > 0 ? (player.pts % 1 === 0 ? player.pts : player.pts.toFixed(1)) : '—';
-        const intensity = player.pts > 0 ? 0.05 + (player.pts / POS_PTS[0]) * 0.28 : 0.03;
-        const rgb = player.team === 'A' ? '240,180,41' : '74,158,255';
-        row.style.background = `rgba(${rgb},${intensity.toFixed(3)})`;
-      }
-    }
-    updateScoreboard();
-  });
-}
-
-/* ─────────────────────────────────────
-   SCORING CALCULATIONS
-───────────────────────────────────── */
-function calcDay1() {
-  let a = 0, b = 0;
-  state.day1.matches.forEach(match => {
-    if (match.winner === 'A') a += 2;
-    else if (match.winner === 'B') b += 2;
-    else if (match.winner === 'AS') { a += 1; b += 1; }
-  });
-  return { a, b };
-}
-
-function calcDay2() {
-  const a = (scramblePoints(state.day2.a4)||0) + (scramblePoints(state.day2.a2)||0);
-  const b = (scramblePoints(state.day2.b4)||0) + (scramblePoints(state.day2.b2)||0);
-  return { a, b };
-}
-
-function calcDay3() {
-  const { sorted } = computeDay3();
-  let a = 0, b = 0;
-  sorted.forEach(p => {
-    if (p.team === 'A') a += p.pts;
-    else                b += p.pts;
-  });
-  return { a, b };
-}
-
-function isDay1Complete() {
-  return state.day1.matches.every(m => m.winner !== null);
-}
-
-function isDay2Complete() {
-  return ['a4','a2','b4','b2'].every(k => state.day2[k] !== null && state.day2[k] !== '');
-}
-
-function isDay3Complete() {
-  return PLAYERS.every(p => state.day3[p.id] !== undefined && state.day3[p.id] !== '');
-}
-
-/* ─────────────────────────────────────
-   SCOREBOARD UPDATE
-───────────────────────────────────── */
-function updateScoreboard() {
-  updateTeamNames();
-  const d1 = calcDay1();
-  const d2 = calcDay2();
-  const d3 = calcDay3();
-  const totalA = d1.a + d2.a + d3.a;
-  const totalB = d1.b + d2.b + d3.b;
-
-  const sbA = document.getElementById('sb-total-a');
-  const sbB = document.getElementById('sb-total-b');
-
-  const prevA = parseFloat(sbA.textContent) || 0;
-  const prevB = parseFloat(sbB.textContent) || 0;
-
-  sbA.textContent = fmt(totalA);
-  sbB.textContent = fmt(totalB);
-
-  if (fmt(totalA) !== fmt(prevA)) { sbA.classList.remove('pop'); void sbA.offsetWidth; sbA.classList.add('pop'); }
-  if (fmt(totalB) !== fmt(prevB)) { sbB.classList.remove('pop'); void sbB.offsetWidth; sbB.classList.add('pop'); }
-
-  document.getElementById('sb-chips-a').innerHTML =
-    `<span class="sb-chip">D1: ${fmt(d1.a)}</span><span class="sb-chip">D2: ${fmt(d2.a)}</span><span class="sb-chip">D3: ${fmt(d3.a)}</span>`;
-  document.getElementById('sb-chips-b').innerHTML =
-    `<span class="sb-chip">D1: ${fmt(d1.b)}</span><span class="sb-chip">D2: ${fmt(d2.b)}</span><span class="sb-chip">D3: ${fmt(d3.b)}</span>`;
-
-  const banner = document.getElementById('win-banner');
-  const allDone = isDay1Complete() && isDay2Complete() && isDay3Complete();
-  if (allDone) {
-    if (totalA > totalB) {
-      banner.className = 'win-banner';
-      banner.textContent = `🏆 ${state.teamNameA.toUpperCase()} WIN THE WONGA CUP — ${fmt(totalA)} to ${fmt(totalB)} 🏆`;
-      banner.style.display = '';
-    } else if (totalB > totalA) {
-      banner.className = 'win-banner';
-      banner.textContent = `🏆 ${state.teamNameB.toUpperCase()} WIN THE WONGA CUP — ${fmt(totalB)} to ${fmt(totalA)} 🏆`;
-      banner.style.display = '';
-    } else {
-      banner.className = 'sd-banner';
-      banner.textContent = `⚡ SUDDEN DEATH PUTT-OFF REQUIRED — ${fmt(totalA)} ALL ⚡`;
-      banner.style.display = '';
-    }
-  } else {
-    banner.style.display = 'none';
-  }
-  updateMiniScoreboard();
-}
-
-/* ─────────────────────────────────────
-   LIVE SYNC — URL HASH ENCODING
-   State is always reflected in the URL
-   hash so copying the page URL gives a
-   snapshot anyone can load.
-───────────────────────────────────── */
-
-
-/* ─────────────────────────────────────
-   SUPABASE SYNC FUNCTIONS
-───────────────────────────────────── */
-function showSaveToast(message, type) {
-  const toast = document.getElementById('save-toast');
-  toast.textContent = message;
-  toast.className = `save-toast show ${type}`;
-  if (type !== 'saving') {
-    setTimeout(() => toast.classList.remove('show'), 2000);
-  }
-}
-
-async function insertUpdate(updateType, fields) {
-  if (!SUPABASE_CONFIG.apiUrl || !SUPABASE_CONFIG.apiKey || !currentUsername) return;
-  showSaveToast('Saving...', 'saving');
-  const row = {
-    tournament_id: SUPABASE_CONFIG.tournamentId,
-    update_type: updateType,
-    updated_by: currentUsername,
-    match_idx:  fields.match_idx  !== undefined ? fields.match_idx  : null,
-    player_id:  fields.player_id  !== undefined ? fields.player_id  : null,
-    field_key:  fields.field_key  !== undefined ? String(fields.field_key) : null,
-    value:      fields.value      !== null && fields.value !== undefined ? String(fields.value) : null
-  };
-  try {
-    const resp = await fetch(`${SUPABASE_CONFIG.apiUrl}/rest/v1/tournament_updates`, {
-      method: 'POST',
-      headers: {
-        'apikey': SUPABASE_CONFIG.apiKey,
-        'Content-Type': 'application/json',
-        'Prefer': 'return=minimal'
-      },
-      body: JSON.stringify(row)
-    });
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${await resp.text()}`);
-    isOffline = false;
-    document.getElementById('offline-banner').style.display = 'none';
-    showSaveToast('✓ Saved', 'success');
-  } catch(err) {
-    console.error('Supabase insert failed:', err.message);
-    isOffline = true;
-    document.getElementById('offline-banner').style.display = 'block';
-    showSaveToast('✗ Offline', 'error');
-  }
-}
-
-function applyUpdate(row) {
-  const v = row.value;
-  switch (row.update_type) {
-    case 'day1_match':
-      if (row.match_idx !== null && row.match_idx !== undefined) {
-        state.day1.matches[row.match_idx].winner = v;
-        if (v === 'AS') state.day1.matches[row.match_idx].margin = null;
-      }
-      break;
-    case 'day1_margin':
-      if (row.match_idx !== null && row.match_idx !== undefined) {
-        state.day1.matches[row.match_idx].margin = v === null || v === 'null' ? null : parseInt(v);
-      }
-      break;
-    case 'day2_score':
-      if (row.field_key) state.day2[row.field_key] = v === null || v === 'null' ? null : v;
-      break;
-    case 'day3_stableford':
-      if (row.player_id !== null && row.player_id !== undefined) {
-        state.day3[row.player_id] = v === null || v === 'null' ? null : v;
-      }
-      break;
-    case 'team_name':
-      if (row.field_key === 'A') state.teamNameA = v;
-      else if (row.field_key === 'B') state.teamNameB = v;
-      break;
-    case 'team_assign':
-      if (row.field_key === 'A') state.teamA = new Set(JSON.parse(v));
-      else if (row.field_key === 'B') state.teamB = new Set(JSON.parse(v));
-      break;
-  }
-}
-
-async function loadFromSupabase() {
-  if (!SUPABASE_CONFIG.apiUrl || !SUPABASE_CONFIG.apiKey) {
-    console.log('Supabase not configured');
-    return false;
-  }
-  const lastSync = localStorage.getItem(LAST_SYNC_KEY) || '1970-01-01T00:00:00.000Z';
-  try {
-    const url = `${SUPABASE_CONFIG.apiUrl}/rest/v1/tournament_updates?tournament_id=eq.${SUPABASE_CONFIG.tournamentId}&updated_at=gt.${encodeURIComponent(lastSync)}&order=updated_at.asc&limit=500`;
-    const resp = await fetch(url, {
-      headers: { 'apikey': SUPABASE_CONFIG.apiKey, 'Content-Type': 'application/json' }
-    });
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-    const rows = await resp.json();
-    if (rows.length > 0) {
-      rows.forEach(row => applyUpdate(row));
-      localStorage.setItem(LAST_SYNC_KEY, rows[rows.length - 1].updated_at);
-    }
-    isOffline = false;
-    document.getElementById('offline-banner').style.display = 'none';
-    return rows.length > 0;
-  } catch(err) {
-    console.error('Supabase load failed:', err.message);
-    isOffline = true;
-    document.getElementById('offline-banner').style.display = 'block';
-    return false;
-  }
-}
-
-/* ─────────────────────────────────────
-   USERNAME & LOGIN
-───────────────────────────────────── */
-var _pendingAction = null;
-
-function requireUsername(action) {
-  if (currentUsername) { if (action) action(); return; }
-  _pendingAction = action || null;
-  document.getElementById('username-modal').classList.remove('hidden');
-  document.getElementById('username-input').focus();
-}
-
-function confirmUsername() {
-  const input = document.getElementById('username-input');
-  const name = input.value.trim();
-  if (!name) {
-    input.style.borderColor = 'var(--gold)';
-    setTimeout(() => { input.style.borderColor = ''; }, 300);
-    return;
-  }
-  currentUsername = name;
-  sessionStorage.setItem('wongaCup_username', name);
-  document.getElementById('username-modal').classList.add('hidden');
-  document.getElementById('username-badge').textContent = `🎯 ${name}`;
-  document.getElementById('username-badge').style.display = 'block';
-  if (_pendingAction) { _pendingAction(); _pendingAction = null; }
-}
-
-function initUsername() {
-  const saved = sessionStorage.getItem('wongaCup_username');
-  if (saved) {
-    currentUsername = saved;
-    document.getElementById('username-badge').textContent = `🎯 ${saved}`;
-    document.getElementById('username-badge').style.display = 'block';
-  }
-  document.getElementById('username-input').addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') confirmUsername();
-  });
-}
-
-
-/* ─────────────────────────────────────
-   MUSIC
-───────────────────────────────────── */
 function startMusic() {
   document.getElementById('music-modal').classList.add('hidden');
   sessionStorage.setItem('musicConsented', '1');
   document.getElementById('bg-audio').play();
 }
-
 function dismissMusic() {
   document.getElementById('music-modal').classList.add('hidden');
-  sessionStorage.setItem('musicConsented', 'dismissed');
+  sessionStorage.setItem('musicConsented', '0');
 }
-
-/* ─────────────────────────────────────
-   INIT
-───────────────────────────────────── */
-if (!sessionStorage.getItem('musicConsented')) {
-  document.getElementById('music-modal').classList.remove('hidden');
-} else if (sessionStorage.getItem('musicConsented') === '1') {
-  document.getElementById('bg-audio').play();
-}
-
-initUsername();
-// Load from shared URL hash first; fall back to localStorage
-loadState();
-renderTeams();
-renderDay1();
-restoreDay2();
-renderDay3();
-updateScoreboard();
-// Load from Supabase on init if configured
-function refreshAllDays() {
-  console.log('Refreshing all day tabs...');
-  try {
-    renderDay1();
-    console.log('Day 1 rendered');
-    restoreDay2();
-    console.log('Day 2 rendered');
-    renderDay3();
-    console.log('Day 3 rendered');
-    updateScoreboard();
-    console.log('Scoreboard updated');
-    renderOverviewTeams();
-    renderFieldTeamBadges();
-  } catch(e) {
-    console.error('Error rendering days:', e);
-  }
-}
-
-if (SUPABASE_CONFIG.apiUrl && SUPABASE_CONFIG.apiKey) {
-  console.log('Starting Supabase polling...');
-  loadFromSupabase().then((success) => {
-    console.log('Initial load success:', success);
-    if (success) refreshAllDays();
-  }).catch(e => console.error('Initial load error:', e));
-
-  // Auto-poll every 30s for everyone (live scores for all players)
-  setInterval(() => {
-    // Skip re-render if we saved within the last 5 seconds to avoid wiping in-progress input
-    if (Date.now() - lastSaveTime < 5000) {
-      console.log('Auto-poll skipped — recent save in progress');
-      return;
-    }
-    console.log('Auto-poll triggered');
-    loadFromSupabase().then((success) => {
-      console.log('Poll load success:', success);
-      if (success) refreshAllDays();
-    }).catch(e => console.error('Poll load error:', e));
-  }, 30000);
-}
-/* ─────────────────────────────────────
-   MINI SCOREBOARD
-───────────────────────────────────── */
-function saveTeamNames() {
-  requireUsername(() => {
-    const a = document.getElementById('tn-input-a').value.trim();
-    const b = document.getElementById('tn-input-b').value.trim();
-    if (a) { state.teamNameA = a; insertUpdate('team_name', { field_key: 'A', value: a }); }
-    if (b) { state.teamNameB = b; insertUpdate('team_name', { field_key: 'B', value: b }); }
-    saveState();
-    updateTeamNames();
-    renderDay1();
-  });
-}
-
-function updateTeamNames() {
-  const a = state.teamNameA, b = state.teamNameB;
-  const ids = {
-    'sb-team-name-a': a, 'sb-team-name-b': b,
-    'team-col-h-a': a,   'team-col-h-b': b,
-    'scramble-title-a': a, 'scramble-title-b': b,
-    'mini-name-a': a,    'mini-name-b': b,
-    'tn-input-a': null,  'tn-input-b': null
-  };
-  Object.entries(ids).forEach(([id, val]) => {
-    const el = document.getElementById(id);
-    if (el && val !== null) el.textContent = val;
-  });
-  const ia = document.getElementById('tn-input-a');
-  const ib = document.getElementById('tn-input-b');
-  if (ia) ia.value = a;
-  if (ib) ib.value = b;
-}
-
-function updateMiniScoreboard() {
-  const d1 = calcDay1();
-  const d2 = calcDay2();
-  const d3 = calcDay3();
-  const totalA = d1.a + d2.a + d3.a;
-  const totalB = d1.b + d2.b + d3.b;
-  document.getElementById('mini-score-a').textContent = fmt(totalA);
-  document.getElementById('mini-score-b').textContent = fmt(totalB);
-  const days = [
-    { label: 'D1', a: d1.a, b: d1.b },
-    { label: 'D2', a: d2.a, b: d2.b },
-    { label: 'D3', a: d3.a, b: d3.b },
-  ];
-  document.getElementById('mini-sb-days').innerHTML = days.map(d => {
-    let cls = 'mini-sb-chip';
-    if (d.a > d.b) cls += ' live-a';
-    else if (d.b > d.a) cls += ' live-b';
-    return `<span class="${cls}">${d.label}: ${fmt(d.a)}–${fmt(d.b)}</span>`;
-  }).join('');
-}
-
-/* ─────────────────────────────────────
-   COUNTDOWN TIMER
-───────────────────────────────────── */
-function updateCountdown() {
-  const bar = document.getElementById('countdown-bar');
-  if (!bar) return;
-  // Tee off: Friday 7 August 2026 14:00 AEST (UTC+10) = 04:00 UTC
-  const target = new Date('2026-08-07T04:00:00Z');
-  const now = new Date();
-  const diff = target - now;
-  if (diff <= 0) {
-    bar.innerHTML = '<span class="cd-live">⛳ WE\'RE LIVE — TEE OFF!</span>';
-    return;
-  }
-  const days    = Math.floor(diff / 86400000);
-  const hours   = Math.floor((diff % 86400000) / 3600000);
-  const minutes = Math.floor((diff % 3600000) / 60000);
-  const seconds = Math.floor((diff % 60000) / 1000);
-  bar.innerHTML =
-    `<span class="cd-label">Tee Off In</span>` +
-    `<span class="cd-unit"><span class="cd-num">${String(days).padStart(2,'0')}</span><span class="cd-sub">Days</span></span>` +
-    `<span class="cd-sep">:</span>` +
-    `<span class="cd-unit"><span class="cd-num">${String(hours).padStart(2,'0')}</span><span class="cd-sub">Hrs</span></span>` +
-    `<span class="cd-sep">:</span>` +
-    `<span class="cd-unit"><span class="cd-num">${String(minutes).padStart(2,'0')}</span><span class="cd-sub">Min</span></span>` +
-    `<span class="cd-sep">:</span>` +
-    `<span class="cd-unit"><span class="cd-num">${String(seconds).padStart(2,'0')}</span><span class="cd-sub">Sec</span></span>`;
-}
-updateCountdown();
-setInterval(updateCountdown, 1000);
-
-// Masthead scroll behaviour (mirrors index.html)
 (function () {
-  const mast = document.querySelector('.masthead');
-  if (!mast) return;
-  function update() {
-    mast.classList.toggle('masthead--scrolled', window.scrollY > 80);
+  if (!sessionStorage.getItem('musicConsented')) {
+    document.getElementById('music-modal').classList.remove('hidden');
   }
-  window.addEventListener('scroll', update, { passive: true });
-  update();
 })();
+
+// Hamburger / mobile menu
+const hamburger = document.getElementById('hamburger');
+const mobileMenu = document.getElementById('mobile-menu');
+function closeMenu() {
+  mobileMenu.classList.remove('open');
+  mobileMenu.setAttribute('aria-hidden', 'true');
+  hamburger.setAttribute('aria-expanded', 'false');
+  hamburger.classList.remove('open');
+}
+hamburger.addEventListener('click', function () {
+  const open = mobileMenu.classList.toggle('open');
+  mobileMenu.setAttribute('aria-hidden', String(!open));
+  hamburger.setAttribute('aria-expanded', String(open));
+  hamburger.classList.toggle('open', open);
+});
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- PR #47 re-introduced the pre-#38 `scorecard.html` and wiped `scorecard-live.html`'s test team defaults (set to empty), reverting issue #38's changes.
- Restores `scorecard.html` as the Captain's Draft pre-draft placeholder page (links to `scorecard-live.html`).
- Restores `scorecard-live.html`'s `DEFAULT_A`/`DEFAULT_B` to a balanced 7v7 test split (`[0,2,4,6,8,10,12]` / `[1,3,5,7,9,11,13]`) for pre-draft testing, per #38.

## Test plan
- [x] Verified `scorecard.html` renders the Captain's Draft explainer and links to `scorecard-live.html`
- [x] Verified `scorecard-live.html` masthead self-link and test team defaults


---
_Generated by [Claude Code](https://claude.ai/code/session_01FmSK3zoJXt8MAJ8NGLdYvt)_