### PR TITLE
Friday Day 1: 5 singles matches instead of singles + doubles

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@
         <div class="cap">The Murray Course · Friday Day 1</div>
       </div>
       <div class="copy">
-        <span class="day-tag">Day I · Friday 7 August · 12:00 PM · Match Play Best Ball</span>
+        <span class="day-tag">Day I · Friday 7 August · 12:00 PM · Singles Match Play</span>
         <h3>The <em>Murray</em> Course</h3>
         <div class="stats">
           <div class="s"><span class="k">Par</span><span class="v">72</span></div>
@@ -194,8 +194,8 @@
         <p>The flagship layout at Yarrawonga Mulwala Golf Club Resort, designed by Peter Thomson (five-time Open champion) and Michael Wolveridge. The Murray Course opened in 1986 and winds through century-old river red gums and native bushland on the sandy flats of the Murray River - an out-and-back routing that keeps the river scenery in play throughout.</p>
         <p>Generous fairways flatter off the tee, but the undulating greens and well-positioned water features make scoring harder than the card suggests. Ranked among Australia's Top 100 public access courses, it's a fitting stage for Day 1 match play.</p>
         <div class="signature">
-          <div class="l">Format · Match Play Best Ball</div>
-          <div class="v">One 1v1 singles, two 2v2 doubles. 10 players (Cayden Woods &amp; Ben Lepore join Saturday). 2 points per match won, 1 each if all square.</div>
+          <div class="l">Format · Singles Match Play</div>
+          <div class="v">Five 1v1 singles matches. 10 players (Cayden Woods &amp; Ben Lepore join Saturday). Each match splits into a front 9 and back 9, worth 1pt apiece — 0.5pt each if a nine is halved.</div>
         </div>
       </div>
     </article>
@@ -272,9 +272,9 @@
           <div class="dt">Day I · Match Play</div>
         </div>
         <div class="what">
-          <div class="frm">Match Play Best Ball · 10 players · Murray Course</div>
-          <h3>The first ten arrivals tee off at noon. One singles, two doubles per side.</h3>
-          <p>Teams are set by Captain's Draft on Friday morning — the two peer-vote captains pick in snake order until all players are assigned. Two doubles, one singles — 3 matches, 6 points up for grabs. Each match splits into a front 9 and back 9, worth 1pt apiece — 0.5pt each if a nine is halved. Cayden Woods &amp; Ben Lepore join the field Saturday morning.</p>
+          <div class="frm">Singles Match Play · 10 players · Murray Course</div>
+          <h3>The first ten arrivals tee off at noon. Five 1v1 singles matches.</h3>
+          <p>Teams are set by Captain's Draft on Friday morning — the two peer-vote captains pick in snake order until all players are assigned. Five singles matches — 10 points up for grabs. Each match splits into a front 9 and back 9, worth 1pt apiece — 0.5pt each if a nine is halved. Cayden Woods &amp; Ben Lepore join the field Saturday morning.</p>
         </div>
         <div class="runs">
           <div class="item"><div class="t">Morning</div><div class="x">Captain's Draft · teams drawn before tee-off<em>Peer vote captains; snake draft fills the sides</em></div></div>

--- a/scorecard-live.html
+++ b/scorecard-live.html
@@ -417,9 +417,9 @@ body{padding-bottom:52px}
     <div class="sc-panel" id="sc-day1">
       <div class="section-header" style="padding-top:28px">
         <div class="section-label">Friday 7 August · Murray Course · 12:00pm</div>
-        <div class="section-title">Match Play Best Ball</div>
+        <div class="section-title">Singles Match Play</div>
       </div>
-      <div class="info-box">10 players play Friday (Cayden Woods &amp; Ben Lepore join Saturday). Assign Friday players to matches below. <strong>Scoring:</strong> each match is split into a front 9 and back 9 — tap the winning team for each half (1pt), or Tie if it's halved (0.5pt each). 6pts up for grabs across the day.</div>
+      <div class="info-box">10 players play Friday (Cayden Woods &amp; Ben Lepore join Saturday) across 5 singles matches, 1v1. Assign Friday players to matches below. <strong>Scoring:</strong> each match is split into a front 9 and back 9 — tap the winning team for each half (1pt), or Tie if it's halved (0.5pt each). 10pts up for grabs across the day.</div>
       <div id="day1-matches"></div>
     </div>
 
@@ -569,9 +569,11 @@ const state = {
   teamB: new Set(DEFAULT_B),
   day1: {
     matches: [
-      { type:'singles', pA:[null],      pB:[null],      front9:null, back9:null },
-      { type:'doubles', pA:[null,null], pB:[null,null], front9:null, back9:null },
-      { type:'doubles', pA:[null,null], pB:[null,null], front9:null, back9:null }
+      { type:'singles', pA:[null], pB:[null], front9:null, back9:null },
+      { type:'singles', pA:[null], pB:[null], front9:null, back9:null },
+      { type:'singles', pA:[null], pB:[null], front9:null, back9:null },
+      { type:'singles', pA:[null], pB:[null], front9:null, back9:null },
+      { type:'singles', pA:[null], pB:[null], front9:null, back9:null }
     ]
   },
   day2: { a4:null, a2:null, b4:null, b2:null },
@@ -750,7 +752,7 @@ function playerOptions(team, matchIdx, slot, currentId) {
 function renderDay1() {
   const container = document.getElementById('day1-matches');
   container.innerHTML = '';
-  const titles = ['Match 1 — Singles (1v1)', 'Match 2 — Doubles (2v2)', 'Match 3 — Doubles (2v2)'];
+  const titles = ['Match 1 — Singles (1v1)', 'Match 2 — Singles (1v1)', 'Match 3 — Singles (1v1)', 'Match 4 — Singles (1v1)', 'Match 5 — Singles (1v1)'];
 
   state.day1.matches.forEach((match, mi) => {
     const { pA, pB, front9, back9, type } = match;


### PR DESCRIPTION
## Summary
- Friday Day 1 is now **5 singles matches (1v1)** instead of 1 singles + 2 doubles, using the same 10 players.
- Each match still splits into front 9 / back 9 (1pt each, 0.5pt if halved), so the Friday total is now **10pts** (was 6pts with 3 matches).
- Updated section title to "Singles Match Play", match titles (Match 1–5), info box copy, and the format descriptions on `index.html` (schedule section + Murray Course signature block).

## Test plan
- [x] Verified `state.day1.matches` has 5 singles entries
- [x] Verified scoring logic: 5 matches with mixed front9/back9 results sum to 10 total points
- [x] Verified `isDay1Complete` / `fridayPlayers` still work with 5 matches


---
_Generated by [Claude Code](https://claude.ai/code/session_01FmSK3zoJXt8MAJ8NGLdYvt)_